### PR TITLE
[FEAT#3]: User Entity 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/airfryer/repicka/RepickaApplication.java
+++ b/src/main/java/com/airfryer/repicka/RepickaApplication.java
@@ -2,8 +2,10 @@ package com.airfryer.repicka;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class RepickaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/airfryer/repicka/common/entity/BaseEntity.java
+++ b/src/main/java/com/airfryer/repicka/common/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.airfryer.repicka.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime created_at;
+
+    @LastModifiedDate
+    private LocalDateTime updated_at;
+}

--- a/src/main/java/com/airfryer/repicka/common/entity/BaseEntity.java
+++ b/src/main/java/com/airfryer/repicka/common/entity/BaseEntity.java
@@ -17,8 +17,8 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime created_at;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updated_at;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/Gender.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/Gender.java
@@ -1,0 +1,14 @@
+package com.airfryer.repicka.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Gender {
+    MALE("M", "남성"),
+    FEMALE("F", "여성");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/Role.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/Role.java
@@ -1,0 +1,14 @@
+package com.airfryer.repicka.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Role {
+    USER("ROLE_USER", "일반 사용자"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long user_id; // 사용자 식별자
+    private Long userId; // 사용자 식별자
 
     @NotNull
     private String email; // 이메일
@@ -24,28 +24,28 @@ public class User extends BaseEntity {
     private String nickname; // 별명
 
     @NotNull
-    private String login_method; // 소셜 로그인 정보
+    private String loginMethod; // 소셜 로그인 정보
 
     @NotNull
     @Enumerated(EnumType.STRING)
     private Role role; // 권한
 
     @NotNull
-    private String profile_image_url; // 프로필 이미지 URL
+    private String profileImageUrl; // 프로필 이미지 URL
 
     @NotNull
-    private boolean is_korea_univ_verified; // 고려대 학생 인증 여부
+    private boolean isKoreaUnivVerified; // 고려대 학생 인증 여부
 
     @Enumerated(EnumType.STRING)
     private Gender gender; // 성별 (F,M)
 
     private int height; // 키
     private int weight; // 몸무게
-    private String fcm_token; // 푸시알림 토큰
+    private String fcmToken; // 푸시알림 토큰
 
     @NotNull
-    private int today_post_count; // 오늘 등록한 게시글 개수
+    private int todayPostCount; // 오늘 등록한 게시글 개수
 
     @NotNull
-    private LocalDate last_access_date; // 마지막 접속 날짜
+    private LocalDate lastAccessDate; // 마지막 접속 날짜
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.airfryer.repicka.domain.user.entity;
 
 import com.airfryer.repicka.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,23 +17,23 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long user_id; // 사용자 식별자
 
-    @Column(nullable = false)
+    @NotNull
     private String email; // 이메일
 
-    @Column(nullable = false)
+    @NotNull
     private String nickname; // 별명
 
-    @Column(nullable = false)
+    @NotNull
     private String login_method; // 소셜 로그인 정보
 
-    @Column(nullable = false)
+    @NotNull
     @Enumerated(EnumType.STRING)
     private Role role; // 권한
 
-    @Column(nullable = false)
+    @NotNull
     private String profile_image_url; // 프로필 이미지 URL
 
-    @Column(nullable = false)
+    @NotNull
     private boolean is_korea_univ_verified; // 고려대 학생 인증 여부
 
     @Enumerated(EnumType.STRING)
@@ -42,9 +43,9 @@ public class User extends BaseEntity {
     private int weight; // 몸무게
     private String fcm_token; // 푸시알림 토큰
 
-    @Column(nullable = false)
+    @NotNull
     private int today_post_count; // 오늘 등록한 게시글 개수
 
-    @Column(nullable = false)
+    @NotNull
     private LocalDate last_access_date; // 마지막 접속 날짜
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.airfryer.repicka.domain.user.entity;
 
+import com.airfryer.repicka.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,7 @@ import java.time.LocalDate;
 @Getter
 @Table(name = "users")
 @NoArgsConstructor
-public class User {
+public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long user_id; // 사용자 식별자
@@ -46,10 +47,4 @@ public class User {
 
     @Column(nullable = false)
     private LocalDate last_access_date; // 마지막 접속 날짜
-
-    @Column(nullable = false)
-    private LocalDate created_at; // 레코드 생성 날짜
-
-    @Column(nullable = false)
-    private LocalDate updated_at; // 레코드 수정 날짜
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -3,15 +3,16 @@ package com.airfryer.repicka.domain.user.entity;
 import com.airfryer.repicka.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Entity
-@Getter
 @Table(name = "users")
-@NoArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -1,5 +1,55 @@
-package com.airfryer.repicka.domain.user;
+package com.airfryer.repicka.domain.user.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "users")
+@NoArgsConstructor
 public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long user_id; // 사용자 식별자
 
+    @Column(nullable = false)
+    private String email; // 이메일
+
+    @Column(nullable = false)
+    private String nickname; // 별명
+
+    @Column(nullable = false)
+    private String login_method; // 소셜 로그인 정보
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role; // 권한
+
+    @Column(nullable = false)
+    private String profile_image_url; // 프로필 이미지 URL
+
+    @Column(nullable = false)
+    private boolean is_korea_univ_verified; // 고려대 학생 인증 여부
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender; // 성별 (F,M)
+
+    private int height; // 키
+    private int weight; // 몸무게
+    private String fcm_token; // 푸시알림 토큰
+
+    @Column(nullable = false)
+    private int today_post_count; // 오늘 등록한 게시글 개수
+
+    @Column(nullable = false)
+    private LocalDate last_access_date; // 마지막 접속 날짜
+
+    @Column(nullable = false)
+    private LocalDate created_at; // 레코드 생성 날짜
+
+    @Column(nullable = false)
+    private LocalDate updated_at; // 레코드 수정 날짜
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -1,0 +1,5 @@
+package com.airfryer.repicka.domain.user;
+
+public class User {
+
+}


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#3 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
### Gender
유저 정보 중 성별에서 선택 가능한 Enum 입니다.

### Role
유저 정보 중 역할(권한)에서 선택 가능한 Enum 입니다.

### BaseEntity
created_at, update_at 등 auditing 기능을 이용하여 자동으로 날짜를 저장할 수 있도록 하는 기본 엔터티입니다.

### User
유저 정보를 포함하고 있는 Entity로 BaseEntity를 상속받고 있습니다.
ERD 구성대로 설정하였으며, 실제 DB 상에는 users 이름으로 저장됩니다.


<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- 소셜 로그인 정보 Enum 분리?

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
- 데코레이터 더 추가해야 하는지 아니면 잘못 추가한 부분이 있는지 확인해주세요!!
- 엔터티 객체 내 변수 명 snake_case로 하나요 아니면 camelCase로 바꿀까요?

<br>