### PR TITLE
[FEAT#5]: 기본 보안 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,15 +24,31 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	compileOnly 'org.projectlombok:lombok'
+	// 개발 도구
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-	annotationProcessor 'org.projectlombok:lombok'
+
+	// 테스트
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Spring Web
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// Spring Data JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// 데이터 검증
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// MariaDB
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CustomExceptionCode
 {
-    // 로그인 관련 예외
+    // 권한 관련 예외
+    NOT_LOGIN(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+
     EXAMPLE_EXCEPTION(HttpStatus.NOT_FOUND, "예외 예시입니다.");
 
     private final HttpStatus httpStatus;    // HTTP 상태 코드

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -10,6 +10,7 @@ public enum CustomExceptionCode
 {
     // 권한 관련 예외
     NOT_LOGIN(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+    LOW_AUTHORITY(HttpStatus.UNAUTHORIZED, "권한이 부족합니다."),
 
     EXAMPLE_EXCEPTION(HttpStatus.NOT_FOUND, "예외 예시입니다.");
 

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -1,0 +1,56 @@
+package com.airfryer.repicka.common.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig
+{
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception
+    {
+        // 기본 설정
+        httpSecurity
+                .httpBasic(HttpBasicConfigurer::disable)
+                .csrf(CsrfConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .headers(c -> c.frameOptions(
+                        HeadersConfigurer.FrameOptionsConfig::disable).disable())
+                .sessionManagement(c -> c.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS));
+
+        return httpSecurity.build();
+    }
+
+    // CORS 설정
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource()
+    {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedOrigins(List.of("http://localhost:5173"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.airfryer.repicka.common.security;
 
+import com.airfryer.repicka.common.security.exception.CustomAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -19,8 +21,12 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig
 {
+    // 예외 처리 클래스
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception
     {
@@ -33,6 +39,11 @@ public class SecurityConfig
                         HeadersConfigurer.FrameOptionsConfig::disable).disable())
                 .sessionManagement(c -> c.sessionCreationPolicy(
                         SessionCreationPolicy.STATELESS));
+
+        // 예외 처리 설정
+        httpSecurity
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(authenticationEntryPoint));
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.airfryer.repicka.common.security;
 
+import com.airfryer.repicka.common.security.exception.CustomAccessDeniedHandler;
 import com.airfryer.repicka.common.security.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +27,7 @@ public class SecurityConfig
 {
     // 예외 처리 클래스
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception
@@ -43,7 +45,8 @@ public class SecurityConfig
         // 예외 처리 설정
         httpSecurity
                 .exceptionHandling(exception -> exception
-                        .authenticationEntryPoint(authenticationEntryPoint));
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler));
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/airfryer/repicka/common/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/airfryer/repicka/common/security/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.airfryer.repicka.common.security.exception;
+
+import com.airfryer.repicka.common.exception.CustomExceptionCode;
+import com.airfryer.repicka.common.response.ExceptionResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 권한이 부족한 요청 예외 처리
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler
+{
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ExceptionResponseDto responseDto = ExceptionResponseDto.builder()
+                .code(CustomExceptionCode.LOW_AUTHORITY.name())
+                .message(CustomExceptionCode.LOW_AUTHORITY.getMessage())
+                .data(null)
+                .build();
+
+        response.setStatus(CustomExceptionCode.LOW_AUTHORITY.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(responseDto));
+        response.getWriter().flush();
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/airfryer/repicka/common/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.airfryer.repicka.common.security.exception;
+
+import com.airfryer.repicka.common.exception.CustomExceptionCode;
+import com.airfryer.repicka.common.response.ExceptionResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 권한이 없는 요청 예외 처리
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint
+{
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ExceptionResponseDto responseDto = ExceptionResponseDto.builder()
+                .code(CustomExceptionCode.NOT_LOGIN.name())
+                .message(CustomExceptionCode.NOT_LOGIN.getMessage())
+                .data(null)
+                .build();
+
+        response.setStatus(CustomExceptionCode.NOT_LOGIN.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(responseDto));
+        response.getWriter().flush();
+    }
+}


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
#5 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
### SecurityConfig
Spring Security 전체 설정을 담고 있는 설정 클래스입니다.
CORS 설정 등이 담겨있습니다.

### CustomAuthenticationEntryPoint
권한이 없는 요청을 예외 처리하는 방법을 담은 클래스입니다.
**(ex)** 비로그인 사용자가 로그인이 필요한 요청을 했을 때

### CustomAccessDeniedHandler
권한이 부족한 요청을 예외 처리하는 방법을 담은 클래스입니다.
**(ex)** 일반 사용자가 어드민 권한이 필요한 요청을 했을 때

### 참고
SecurityConfig 클래스에 `@EnableMethodSecurity`가 붙어있습니다.
이는 컨트롤러 각각의 권한을 쉽게 제어하게 해줍니다!
예시는 다음과 같습니다.

```
// 모든 사용자 요청 허용
@GetMapping("/example-permit-all")
@PreAuthorize("permitAll()")
public ResponseEntity<SuccessResponseDto> controller1(...)
{
    ...
}

// 일반 사용자 이상 권한의 요청 허용
@GetMapping("/example-need-login")
@PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
public ResponseEntity<SuccessResponseDto> controller2(...)
{
    ...
}

// 관리자 권한의 요청 허용
@GetMapping("/example-only-admin")
@PreAuthorize("hasAuthority('ADMIN')")
public ResponseEntity<SuccessResponseDto> controller3(...)
{
    ...
}
```

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- OAuth 로그인 구현

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->


<br>