### PR TITLE
[FEAT#7]: OAuth2 구글, 카카오 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// OAuth
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ dependencies {
 
 	// OAuth
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/airfryer/repicka/common/response/SuccessResponseDto.java
+++ b/src/main/java/com/airfryer/repicka/common/response/SuccessResponseDto.java
@@ -1,0 +1,12 @@
+package com.airfryer.repicka.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SuccessResponseDto
+{
+    private String message;     // 메시지
+    private Object data;        // 데이터
+}

--- a/src/main/java/com/airfryer/repicka/common/security/CustomUserDetails.java
+++ b/src/main/java/com/airfryer/repicka/common/security/CustomUserDetails.java
@@ -1,0 +1,38 @@
+package com.airfryer.repicka.common.security;
+
+import com.airfryer.repicka.domain.user.entity.User;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class CustomUserDetails implements OAuth2User
+{
+    private final User user;
+    private final Map<String, Object> attributes;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    @Override
+    public String getName() {
+        return user.getNickname();
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -48,12 +48,6 @@ public class SecurityConfig
                 .sessionManagement(c -> c.sessionCreationPolicy(
                         SessionCreationPolicy.STATELESS));
 
-        // 경로 설정
-        httpSecurity
-                .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/oauth2/**", "/login", "/login/**").permitAll()
-                        .anyRequest().authenticated());
-
         // Oauth 2.0 설정
         httpSecurity
                 .oauth2Login(oauth2 -> oauth2
@@ -62,15 +56,11 @@ public class SecurityConfig
                         .successHandler(oAuth2SuccessHandler)
                 );
 
-        // login 루트도 NOT_LOGIN으로 잡혀서 주석 처리해둠
-        // TODO: NOT_LOGIN, 권한 예외 처리 재설정
-        /*
         // 예외 처리 설정
         httpSecurity
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler));
-         */
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.airfryer.repicka.common.security.exception.CustomAuthenticationEntryP
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -39,13 +40,19 @@ public class SecurityConfig
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .headers(HeadersConfigurer::disable)
                 .sessionManagement(c -> c.sessionCreationPolicy(
-                        SessionCreationPolicy.STATELESS));
+                        SessionCreationPolicy.STATELESS))
+                .oauth2Login(Customizer.withDefaults())
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/", "/oauth2/**", "/login", "/login/**").permitAll()
+                        .anyRequest().authenticated());
 
+        /*
         // 예외 처리 설정
         httpSecurity
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler));
+         */
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.airfryer.repicka.common.security;
 
 import com.airfryer.repicka.common.security.exception.CustomAccessDeniedHandler;
 import com.airfryer.repicka.common.security.exception.CustomAuthenticationEntryPoint;
+import com.airfryer.repicka.common.security.oauth2.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,6 +27,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig
 {
+    // OAuth 처리 서비스
+    private final CustomOAuth2UserService customOAuth2UserService;
+
     // 예외 처리 클래스
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final CustomAccessDeniedHandler accessDeniedHandler;
@@ -41,11 +45,15 @@ public class SecurityConfig
                 .headers(HeadersConfigurer::disable)
                 .sessionManagement(c -> c.sessionCreationPolicy(
                         SessionCreationPolicy.STATELESS))
-                .oauth2Login(Customizer.withDefaults())
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService)))
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/", "/oauth2/**", "/login", "/login/**").permitAll()
                         .anyRequest().authenticated());
 
+        // login 루트도 NOT_LOGIN으로 잡혀서 주석 처리해둠
+        // TODO: NOT_LOGIN, 권한 예외 처리 재설정
         /*
         // 예외 처리 설정
         httpSecurity

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -44,13 +44,19 @@ public class SecurityConfig
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .headers(HeadersConfigurer::disable)
                 .sessionManagement(c -> c.sessionCreationPolicy(
-                        SessionCreationPolicy.STATELESS))
-                .oauth2Login((oauth2) -> oauth2
-                        .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService)))
+                        SessionCreationPolicy.STATELESS));
+
+        // 경로 설정
+        httpSecurity
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/", "/oauth2/**", "/login", "/login/**").permitAll()
                         .anyRequest().authenticated());
+
+        // Oauth 2.0 설정
+        httpSecurity
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService)));
 
         // login 루트도 NOT_LOGIN으로 잡혀서 주석 처리해둠
         // TODO: NOT_LOGIN, 권한 예외 처리 재설정

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig
 
         // Oauth 2.0 설정
         httpSecurity
-                .oauth2Login((oauth2) -> oauth2
+                .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
                                 .userService(customOAuth2UserService)));
 

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.airfryer.repicka.common.security;
 import com.airfryer.repicka.common.security.exception.CustomAccessDeniedHandler;
 import com.airfryer.repicka.common.security.exception.CustomAuthenticationEntryPoint;
 import com.airfryer.repicka.common.security.oauth2.CustomOAuth2UserService;
+import com.airfryer.repicka.common.security.oauth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +30,7 @@ public class SecurityConfig
 {
     // OAuth 처리 서비스
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     // 예외 처리 클래스
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
@@ -56,7 +58,9 @@ public class SecurityConfig
         httpSecurity
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService)));
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                );
 
         // login 루트도 NOT_LOGIN으로 잡혀서 주석 처리해둠
         // TODO: NOT_LOGIN, 권한 예외 처리 재설정

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/JwtFilter.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/JwtFilter.java
@@ -1,0 +1,63 @@
+package com.airfryer.repicka.common.security.jwt;
+
+import com.airfryer.repicka.common.security.oauth2.CustomOAuth2User;
+import com.airfryer.repicka.common.security.oauth2.CustomOAuth2UserService;
+import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.domain.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter
+{
+    private final JwtUtil jwtUtil;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException
+    {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        // 헤더에 토큰이 존재하는지 체크
+        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer "))
+        {
+            String accessToken = authorizationHeader.substring(7);
+
+            // 토큰이 유효한지 체크
+            if(jwtUtil.checkToken(accessToken))
+            {
+                Long id = jwtUtil.getUserIdFromToken(accessToken);
+                User user = userRepository.findById(id).orElse(null);
+
+                // 존재하는 계정인지 체크
+                if(user != null)
+                {
+                    OAuth2User oAuth2User = new CustomOAuth2User(user);
+
+                    // 접근 권한 인증 토큰 생성
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(oAuth2User, null, oAuth2User.getAuthorities());
+
+                    // 현재 요청의 security context에 접근 권한 부여
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                }
+            }
+        }
+
+        // 다음 필터로 전달
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/JwtUtil.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/JwtUtil.java
@@ -18,28 +18,22 @@ import java.util.Date;
 public class JwtUtil
 {
     private final Key key;
-    private final int accessTokenValidTime;
-    private final int refreshTokenValidTime;
 
     // 생성자
-    public JwtUtil(@Value("${JWT_SECRET}") String secret,
-                   @Value("${ACCESS_TOKEN_VALID_TIME}") String accessTokenValidTime,
-                   @Value("${REFRESH_TOKEN_VALID_TIME}") String refreshTokenValidTime)
+    public JwtUtil(@Value("${JWT_SECRET}") String secret)
     {
         byte[] keyBytes = Decoders.BASE64.decode(secret);
         this.key = Keys.hmacShaKeyFor(keyBytes);
-        this.accessTokenValidTime = Integer.parseInt(accessTokenValidTime);
-        this.refreshTokenValidTime = Integer.parseInt(refreshTokenValidTime);
     }
 
     // 토큰 생성
-    public String createToken(Long userId, boolean isAccessToken)
+    public String createToken(Long userId, Token tokenType)
     {
         Claims claims = Jwts.claims();
         claims.put("userId", userId);
 
         ZonedDateTime now = ZonedDateTime.now();
-        ZonedDateTime expiresAt = now.plusSeconds(isAccessToken ? accessTokenValidTime : refreshTokenValidTime);
+        ZonedDateTime expiresAt = now.plusSeconds(tokenType.getValidTime());
 
         return Jwts.builder()
                 .setClaims(claims)
@@ -50,14 +44,14 @@ public class JwtUtil
     }
 
     // 토큰을 쿠키로 변환
-    public Cookie parseTokenToCookie(String token, boolean isAccessToken)
+    public Cookie parseTokenToCookie(String token, Token tokenType)
     {
-        Cookie cookie = new Cookie(isAccessToken ? "accessToken" : "refreshToken", token);
+        Cookie cookie = new Cookie(tokenType.getName(), token);
 
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");
-        cookie.setMaxAge(isAccessToken ? accessTokenValidTime : refreshTokenValidTime);
+        cookie.setMaxAge(tokenType.getValidTime());
         cookie.setAttribute("SameSite", "Strict");
 
         return cookie;

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/JwtUtil.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/JwtUtil.java
@@ -1,0 +1,88 @@
+package com.airfryer.repicka.common.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@Component
+public class JwtUtil
+{
+    private final Key key;
+    private final int accessTokenValidTime;
+    private final int refreshTokenValidTime;
+
+    // 생성자
+    public JwtUtil(@Value("${JWT_SECRET}") String secret,
+                   @Value("${ACCESS_TOKEN_VALID_TIME}") String accessTokenValidTime,
+                   @Value("${REFRESH_TOKEN_VALID_TIME}") String refreshTokenValidTime)
+    {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenValidTime = Integer.parseInt(accessTokenValidTime);
+        this.refreshTokenValidTime = Integer.parseInt(refreshTokenValidTime);
+    }
+
+    // 토큰 생성
+    public String createToken(Long userId, boolean isAccessToken)
+    {
+        Claims claims = Jwts.claims();
+        claims.put("userId", userId);
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime expiresAt = now.plusSeconds(isAccessToken ? accessTokenValidTime : refreshTokenValidTime);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(expiresAt.toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰을 쿠키로 변환
+    public Cookie parseTokenToCookie(String token, boolean isAccessToken)
+    {
+        Cookie cookie = new Cookie(isAccessToken ? "accessToken" : "refreshToken", token);
+
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(isAccessToken ? accessTokenValidTime : refreshTokenValidTime);
+        cookie.setAttribute("SameSite", "Strict");
+
+        return cookie;
+    }
+
+    // 토큰 검증
+    public boolean checkToken(String token)
+    {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // 토큰에서 User id 추출
+    public Long getUserIdFromToken(String token)
+    {
+        if(checkToken(token))
+        {
+            Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+            return claims.get("userId", Long.class);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/Token.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/Token.java
@@ -1,0 +1,17 @@
+package com.airfryer.repicka.common.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+
+// JWT 토큰 종류
+@AllArgsConstructor
+@Getter
+public enum Token
+{
+    ACCESS_TOKEN("accessToken", 60 * 60),               // 1시간
+    REFRESH_TOKEN("refreshToken", 60 * 60 * 24 * 30);   // 30일
+
+    private final String name;
+    private final int validTime;
+}

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2User.java
@@ -1,4 +1,4 @@
-package com.airfryer.repicka.common.security;
+package com.airfryer.repicka.common.security.oauth2;
 
 import com.airfryer.repicka.domain.user.entity.User;
 import lombok.EqualsAndHashCode;
@@ -15,7 +15,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Getter
 @EqualsAndHashCode
-public class CustomUserDetails implements OAuth2User
+public class CustomOAuth2User implements OAuth2User
 {
     private final User user;
     private final Map<String, Object> attributes;

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2User.java
@@ -12,13 +12,22 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
-@RequiredArgsConstructor
 @Getter
 @EqualsAndHashCode
 public class CustomOAuth2User implements OAuth2User
 {
     private final User user;
-    private final Map<String, Object> attributes;
+    private Map<String, Object> attributes;
+
+    public CustomOAuth2User(User user) {
+        this.user = user;
+    }
+
+    // OAuth 2.0 로그인 생성자
+    public CustomOAuth2User(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
 
     @Override
     public Map<String, Object> getAttributes() {

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
@@ -1,6 +1,7 @@
 package com.airfryer.repicka.common.security.oauth2;
 
 import com.airfryer.repicka.common.security.oauth2.dto.GoogleResponse;
+import com.airfryer.repicka.common.security.oauth2.dto.KakaoResponse;
 import com.airfryer.repicka.common.security.oauth2.dto.OAuth2Response;
 import com.airfryer.repicka.domain.user.entity.User;
 import com.airfryer.repicka.domain.user.repository.UserRepository;
@@ -28,8 +29,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuth2Response oAuth2Response = null;
         if (registrationId.equals("google")) {
             oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
-        }
-        else {
+        } else if (registrationId.equals("kakao")) {
+            oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
+        } else {
             return null;
         }
 

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
@@ -6,7 +6,6 @@ import com.airfryer.repicka.common.security.oauth2.dto.OAuth2Response;
 import com.airfryer.repicka.domain.user.entity.User;
 import com.airfryer.repicka.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.parameters.P;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,4 @@
+package com.airfryer.repicka.common.security.oauth2;
+
+public class CustomOAuth2UserService {
+}

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
@@ -1,4 +1,46 @@
 package com.airfryer.repicka.common.security.oauth2;
 
-public class CustomOAuth2UserService {
+import com.airfryer.repicka.common.security.oauth2.dto.GoogleResponse;
+import com.airfryer.repicka.common.security.oauth2.dto.OAuth2Response;
+import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.parameters.P;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response = null;
+        if (registrationId.equals("google")) {
+            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        }
+        else {
+            return null;
+        }
+
+        Optional<User> existUser = userRepository.findByOauthIdAndLoginMethod(oAuth2Response.getProviderId(), oAuth2Response.getProvider());
+        if (existUser == null) {
+            // TODO: 사용자 추가
+        }
+        else {
+            // TODO: 이미 존재하는 사용자에 대한 처리
+        }
+
+        return oAuth2User;
+    }
 }

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -47,7 +48,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if(existUser.isEmpty()) {
             user = User.builder()
                     .email(oAuth2Response.getEmail())
-                    .nickname(oAuth2Response.getName())
+                    .nickname("호랑이" + UUID.randomUUID())
                     .loginMethod(oAuth2Response.getProvider())
                     .oauthId(oAuth2Response.getProviderId())
                     .role(Role.USER)

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.airfryer.repicka.common.security.oauth2;
 
 import com.airfryer.repicka.common.security.jwt.JwtUtil;
+import com.airfryer.repicka.common.security.jwt.Token;
 import com.airfryer.repicka.domain.user.entity.User;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -29,14 +30,12 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler
         User user = userDetails.getUser();
 
         // 토큰 생성
-        String accessToken = jwtUtil.createToken(user.getUserId(), true);
-        String refreshToken = jwtUtil.createToken(user.getUserId(), false);
+        String accessToken = jwtUtil.createToken(user.getUserId(), Token.ACCESS_TOKEN);
+        String refreshToken = jwtUtil.createToken(user.getUserId(), Token.REFRESH_TOKEN);
 
-        // Access token 쿠키 생성
-        Cookie accessTokenCookie = jwtUtil.parseTokenToCookie(accessToken, true);
-
-        // Refresh token 쿠키 생성
-        Cookie refreshTokenCookie = jwtUtil.parseTokenToCookie(refreshToken, false);
+        // 토큰으로 쿠키 생성
+        Cookie accessTokenCookie = jwtUtil.parseTokenToCookie(accessToken, Token.ACCESS_TOKEN);
+        Cookie refreshTokenCookie = jwtUtil.parseTokenToCookie(refreshToken, Token.REFRESH_TOKEN);
 
         // 쿠키 저장
         response.addCookie(accessTokenCookie);

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/GoogleResponse.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/GoogleResponse.java
@@ -1,4 +1,31 @@
 package com.airfryer.repicka.common.security.oauth2.dto;
 
-public class GoogleResponse {
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class GoogleResponse implements OAuth2Response{
+    private final Map<String, Object> attribute;
+
+
+    @Override
+    public String getProvider() {
+        return "GOOGLE";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
 }

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/GoogleResponse.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/GoogleResponse.java
@@ -1,0 +1,4 @@
+package com.airfryer.repicka.common.security.oauth2.dto;
+
+public class GoogleResponse {
+}

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/GoogleResponse.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/GoogleResponse.java
@@ -1,5 +1,6 @@
 package com.airfryer.repicka.common.security.oauth2.dto;
 
+import com.airfryer.repicka.domain.user.entity.LoginMethod;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Map;
@@ -11,7 +12,7 @@ public class GoogleResponse implements OAuth2Response{
 
     @Override
     public String getProvider() {
-        return "GOOGLE";
+        return LoginMethod.GOOGLE.name();
     }
 
     @Override

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/GoogleResponse.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/GoogleResponse.java
@@ -6,13 +6,13 @@ import lombok.RequiredArgsConstructor;
 import java.util.Map;
 
 @RequiredArgsConstructor
-public class GoogleResponse implements OAuth2Response{
+public class GoogleResponse implements OAuth2Response
+{
     private final Map<String, Object> attribute;
 
-
     @Override
-    public String getProvider() {
-        return LoginMethod.GOOGLE.name();
+    public LoginMethod getProvider() {
+        return LoginMethod.GOOGLE;
     }
 
     @Override

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/KakaoResponse.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/KakaoResponse.java
@@ -1,0 +1,32 @@
+package com.airfryer.repicka.common.security.oauth2.dto;
+
+import com.airfryer.repicka.domain.user.entity.LoginMethod;
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class KakaoResponse implements OAuth2Response
+{
+    private Map<String, Object> attributes;
+
+    @Override
+    public String getProvider() {
+        return LoginMethod.KAKAO.name();
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return ((Map<?, ?>) attributes.get("kakao_account")).get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return ((Map<?, ?>) ((Map<?, ?>) attributes.get("kakao_account")).get("profile")).get("nickname").toString();
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/KakaoResponse.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/KakaoResponse.java
@@ -11,8 +11,8 @@ public class KakaoResponse implements OAuth2Response
     private Map<String, Object> attributes;
 
     @Override
-    public String getProvider() {
-        return LoginMethod.KAKAO.name();
+    public LoginMethod getProvider() {
+        return LoginMethod.KAKAO;
     }
 
     @Override

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/OAuth2Response.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/OAuth2Response.java
@@ -1,4 +1,12 @@
 package com.airfryer.repicka.common.security.oauth2.dto;
 
 public interface OAuth2Response {
+    //제공자 (Ex. naver, google, ...)
+    String getProvider();
+    //제공자에서 발급해주는 아이디
+    String getProviderId();
+    //사용자 이메일
+    String getEmail();
+    //사용자 이름
+    String getName();
 }

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/OAuth2Response.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/OAuth2Response.java
@@ -1,12 +1,18 @@
 package com.airfryer.repicka.common.security.oauth2.dto;
 
-public interface OAuth2Response {
-    //제공자 (Ex. naver, google, ...)
-    String getProvider();
-    //제공자에서 발급해주는 아이디
+import com.airfryer.repicka.domain.user.entity.LoginMethod;
+
+public interface OAuth2Response
+{
+    // 제공자 (Ex. naver, google, ...)
+    LoginMethod getProvider();
+
+    // 제공자에서 발급해주는 아이디
     String getProviderId();
-    //사용자 이메일
+
+    // 사용자 이메일
     String getEmail();
-    //사용자 이름
+
+    // 사용자 이름
     String getName();
 }

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/OAuth2Response.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/dto/OAuth2Response.java
@@ -1,0 +1,4 @@
+package com.airfryer.repicka.common.security.oauth2.dto;
+
+public interface OAuth2Response {
+}

--- a/src/main/java/com/airfryer/repicka/domain/test/controller/TestController.java
+++ b/src/main/java/com/airfryer/repicka/domain/test/controller/TestController.java
@@ -1,0 +1,32 @@
+package com.airfryer.repicka.domain.test.controller;
+
+import com.airfryer.repicka.common.response.SuccessResponseDto;
+import com.airfryer.repicka.common.security.oauth2.CustomOAuth2User;
+import com.airfryer.repicka.domain.user.entity.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TestController
+{
+    // 로그인 여부 테스트
+    @GetMapping("/test/is-login")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    public ResponseEntity<SuccessResponseDto> testUser(@AuthenticationPrincipal CustomOAuth2User oAuth2User)
+    {
+        User user = oAuth2User.getUser();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("로그인을 수행한 사용자입니다.")
+                        .data(user.getUserId())
+                        .build());
+    }
+}

--- a/src/main/java/com/airfryer/repicka/domain/test/controller/TestController.java
+++ b/src/main/java/com/airfryer/repicka/domain/test/controller/TestController.java
@@ -18,7 +18,7 @@ public class TestController
 {
     // 로그인 여부 테스트
     @GetMapping("/test/is-login")
-    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> testUser(@AuthenticationPrincipal CustomOAuth2User oAuth2User)
     {
         User user = oAuth2User.getUser();

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/LoginMethod.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/LoginMethod.java
@@ -1,0 +1,14 @@
+package com.airfryer.repicka.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LoginMethod {
+    KAKAO("LOGIN_KAKAO", "카카오 로그인"),
+    GOOGLE("LOGIN_GOOGLE", "구글 로그인");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/LoginMethod.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/LoginMethod.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum LoginMethod {
-    KAKAO("LOGIN_KAKAO", "카카오 로그인"),
-    GOOGLE("LOGIN_GOOGLE", "구글 로그인");
+    GOOGLE("google", "구글 로그인"),
+    KAKAO("kakao", "카카오 로그인");
 
-    private final String code;
+    private final String provider;
     private final String label;
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -8,7 +8,12 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "users")
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"email", "login_method"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -25,7 +30,11 @@ public class User extends BaseEntity {
     private String nickname; // 별명
 
     @NotNull
-    private String loginMethod; // 소셜 로그인 정보
+    @Enumerated(EnumType.STRING)
+    private LoginMethod loginMethod; // 소셜 로그인 정보
+
+    @NotNull
+    private String oauthId;
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -34,7 +34,7 @@ public class User extends BaseEntity {
     private LoginMethod loginMethod; // 소셜 로그인 정보
 
     @NotNull
-    private String oauthId;
+    private String oauthId; // OAuth2 제공자에서 발급해주는 ID
 
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -49,8 +49,8 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Gender gender; // 성별 (F,M)
 
-    private int height; // 키
-    private int weight; // 몸무게
+    private Integer height; // 키
+    private Integer weight; // 몸무게
     private String fcmToken; // 푸시알림 토큰
 
     @NotNull

--- a/src/main/java/com/airfryer/repicka/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/repository/UserRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByOauthIdAndLoginMethod(String oauthId, LoginMethod loginMethod);
+    Optional<User> findByOauthIdAndLoginMethod(String oauthId, String loginMethod);
 
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/repository/UserRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
-
-    Optional<User> findByOauthIdAndLoginMethod(String oauthId, String loginMethod);
-
+public interface UserRepository extends JpaRepository<User, Long>
+{
+    // oauthId와 로그인 방식으로 사용자 찾기
+    Optional<User> findByOauthIdAndLoginMethod(String oauthId, LoginMethod loginMethod);
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.airfryer.repicka.domain.user.repository;
+
+import com.airfryer.repicka.domain.user.entity.LoginMethod;
+import com.airfryer.repicka.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByOauthIdAndLoginMethod(String oauthId, LoginMethod loginMethod);
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,14 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MariaDBDialect
+
+  ## OAuth 설정
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            scope: profile, email

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,19 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             redirect-uri: ${GOOGLE_REDIRECT_URI}
             scope: profile, email
+
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            scope: profile_nickname, account_email
+            authorization-grant-type: authorization_code
+            client-name: Kakao
+            client-authentication-method: client_secret_post
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize?prompt=login
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#7 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
- **OAuth2 로그인 로직 구현**
   
   - **CustomOAuth2User** : OAuth2 로그인 성공 시 반환된 사용자 정보 클래스
   - **CustomOAuth2UserService** : OAuth2 로그인 성공 시 반환된 사용자 정보를 CustomOAuth2User 객체와 연결해주는 서비스
   - **OAuth2SuccessHandler** : OAuth2 로그인 성공 후처리 핸들러

<br>

- **JWT 토큰 관련 로직 구현**

   - **JwtFilter** : JWT 인증 필터
   - **JwtUtil** : JWT 토큰 관련 유틸 함수 클래스
      - **createToken** : Access token / Refresh token 발급 메서드
      - **parseTokenToCookie** : 토큰을 쿠키로 변환하는 메서드
      - **checkToken** : 토큰을 검증하는 메서드
      - **getUserIdFromToken** : 토큰으로부터 userId를 추출하는 메서드

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- OAuth2SuccessHandler에서 OAuth2 로그인 성공 후, 프론트로 리다이렉트하는 로직 구현하기

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
- OAuth2 로그인 성공 후, 프론트로 어떻게 리다이렉트할까?
- 구글, 카카오 말고 또 구현할 소셜 로그인 방식이 있을까?

<br>