### PR TITLE
[FEAT#11]: [ 제품, 제품 이미지, 게시글, 좋아요, 약속 ] 엔티티 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// PostgreSQL
-	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.5'
-	runtimeOnly 'org.postgresql:postgresql'
+	implementation 'org.postgresql:postgresql:42.7.5'
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,9 @@ dependencies {
 	// 데이터 검증
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	// MariaDB
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	// PostgreSQL
+	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.5'
+	runtimeOnly 'org.postgresql:postgresql'
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	// Spring Data JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
 	// PostgreSQL
 	implementation 'org.postgresql:postgresql:42.7.5'
+	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.9.10'
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
@@ -30,8 +30,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler
         User user = userDetails.getUser();
 
         // 토큰 생성
-        String accessToken = jwtUtil.createToken(user.getUserId(), Token.ACCESS_TOKEN);
-        String refreshToken = jwtUtil.createToken(user.getUserId(), Token.REFRESH_TOKEN);
+        String accessToken = jwtUtil.createToken(user.getId(), Token.ACCESS_TOKEN);
+        String refreshToken = jwtUtil.createToken(user.getId(), Token.REFRESH_TOKEN);
 
         // 토큰으로 쿠키 생성
         Cookie accessTokenCookie = jwtUtil.parseTokenToCookie(accessToken, Token.ACCESS_TOKEN);

--- a/src/main/java/com/airfryer/repicka/domain/appointment/entity/Appointment.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/entity/Appointment.java
@@ -1,0 +1,73 @@
+package com.airfryer.repicka.domain.appointment.entity;
+
+import com.airfryer.repicka.common.entity.BaseEntity;
+import com.airfryer.repicka.domain.item.entity.Item;
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.user.entity.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "appointment"
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Appointment extends BaseEntity
+{
+    // 약속 식별자
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 게시글
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post")
+    private Post post;
+
+    // 소유자
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner")
+    private User owner;
+
+    // 대여자
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "borrower")
+    private User borrower;
+
+    // 대여 장소
+    @Column(length = 255)
+    private String rentalLocation;
+
+    // 반납 장소
+    @Column(length = 255)
+    private String returnLocation;
+
+    // 대여 일시
+    @NotNull
+    private LocalDateTime rentalDate;
+
+    // 반납 일시
+    @NotNull
+    private LocalDateTime returnDate;
+
+    // 대여료 / 판매값
+    @NotNull
+    private int price;
+
+    // 보증금
+    private int deposit;
+
+    // 약속 진행 상태
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AppointmentState state;
+}

--- a/src/main/java/com/airfryer/repicka/domain/appointment/entity/Appointment.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/entity/Appointment.java
@@ -64,7 +64,9 @@ public class Appointment extends BaseEntity
     private int price;
 
     // 보증금
-    private int deposit;
+    @NotNull
+    @Builder.Default
+    private int deposit = 0;
 
     // 약속 진행 상태
     @NotNull

--- a/src/main/java/com/airfryer/repicka/domain/appointment/entity/AppointmentState.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/entity/AppointmentState.java
@@ -1,0 +1,18 @@
+package com.airfryer.repicka.domain.appointment.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AppointmentState
+{
+    PENDING("PENDING", "제시"),
+    CONFIRMED("CONFIRMED", "확정"),
+    CANCELLED("CANCELLED", "취소"),
+    EXPIRED("EXPIRED", "만료"),
+    SUCCESS("SUCCESS", "완료");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
@@ -1,0 +1,7 @@
+package com.airfryer.repicka.domain.appointment.repository;
+
+import com.airfryer.repicka.domain.appointment.entity.Appointment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppointmentRepository extends JpaRepository<Appointment, Long> {
+}

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/CurrentItemState.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/CurrentItemState.java
@@ -1,0 +1,17 @@
+package com.airfryer.repicka.domain.item.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CurrentItemState
+{
+    AVAILABLE("AVAILABLE", "가능"),
+    RESERVED("RESERVED", "대여 예정"),
+    RENTED("RENTED", "대여중"),
+    SOLD_OUT("SOLD_OUT", "판매됨");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
@@ -1,0 +1,79 @@
+package com.airfryer.repicka.domain.item.entity;
+
+import com.airfryer.repicka.common.entity.BaseEntity;
+import io.hypersistence.utils.hibernate.type.array.EnumArrayType;
+import io.hypersistence.utils.hibernate.type.array.StringArrayType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.annotations.Type;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "item"
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Item extends BaseEntity
+{
+    // 제품 식별자
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 제품 타입
+    @NotNull
+    @Type(value = EnumArrayType.class)
+    @Column(
+            name = "product_type",
+            columnDefinition = "text[]"
+    )
+    private ProductType[] productType;
+
+    // 사이즈
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private ItemSize size;
+
+    // 제목
+    @NotNull
+    @Column(length = 255)
+    private String title;
+
+    // 설명
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    // 색상
+    @Enumerated(EnumType.STRING)
+    private ItemColor color;
+
+    // 품질
+    @Enumerated(EnumType.STRING)
+    private ItemQuality quality;
+
+    // 장소
+    @Column(length = 255)
+    private String location;
+
+    // 거래 방식
+    @Enumerated(EnumType.STRING)
+    private TradeMethod tradeMethod;
+
+    // 가격 제시 가능 여부
+    @NotNull
+    private Boolean canDeal;
+
+    // 현재 제품 상태
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private CurrentItemState state;
+
+    // 끌올 날짜
+    @NotNull
+    private LocalDateTime repostDate;
+}

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
@@ -4,6 +4,7 @@ import com.airfryer.repicka.common.entity.BaseEntity;
 import io.hypersistence.utils.hibernate.type.array.EnumArrayType;
 import io.hypersistence.utils.hibernate.type.array.StringArrayType;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.annotations.Type;
@@ -26,13 +27,19 @@ public class Item extends BaseEntity
     private Long id;
 
     // 제품 타입
-    @NotNull
-    @Type(value = StringArrayType.class)
+    @NotEmpty
+    @Type(
+            value = EnumArrayType.class,
+            parameters = @org.hibernate.annotations.Parameter(
+                    name = EnumArrayType.SQL_ARRAY_TYPE,
+                    value = "text"
+            )
+    )
     @Column(
             name = "product_type",
             columnDefinition = "text[]"
     )
-    private ProductType[] productType;
+    private ProductType[] productTypes;
 
     // 사이즈
     @NotNull

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
@@ -39,6 +39,7 @@ public class Item extends BaseEntity
             name = "product_type",
             columnDefinition = "text[]"
     )
+    @Builder.Default
     private ProductType[] productTypes = new ProductType[2];
 
     // 사이즈

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
@@ -27,7 +27,7 @@ public class Item extends BaseEntity
 
     // 제품 타입
     @NotNull
-    @Type(value = EnumArrayType.class)
+    @Type(value = StringArrayType.class)
     @Column(
             name = "product_type",
             columnDefinition = "text[]"

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/Item.java
@@ -39,7 +39,7 @@ public class Item extends BaseEntity
             name = "product_type",
             columnDefinition = "text[]"
     )
-    private ProductType[] productTypes;
+    private ProductType[] productTypes = new ProductType[2];
 
     // 사이즈
     @NotNull

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/ItemColor.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/ItemColor.java
@@ -9,9 +9,9 @@ public enum ItemColor
 {
     CRIMSON("CRIMSON", "크림슨"),
     WHITE("CRIMSON", "하양"),
-    BLACK("CRIMSON", "검정"),
-    IVORY("CRIMSON", "아이보리"),
-    OTHER("CRIMSON", "기타");
+    BLACK("BLACK", "검정"),
+    IVORY("IVORY", "아이보리"),
+    OTHER("OTHER", "기타");
 
     private final String code;
     private final String label;

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/ItemColor.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/ItemColor.java
@@ -1,0 +1,18 @@
+package com.airfryer.repicka.domain.item.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ItemColor
+{
+    CRIMSON("CRIMSON", "크림슨"),
+    WHITE("CRIMSON", "하양"),
+    BLACK("CRIMSON", "검정"),
+    IVORY("CRIMSON", "아이보리"),
+    OTHER("CRIMSON", "기타");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/ItemQuality.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/ItemQuality.java
@@ -7,10 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ItemQuality
 {
-    BEST("CRIMSON", "최상"),
-    HIGH("CRIMSON", "상"),
-    MIDDLE("CRIMSON", "중"),
-    LOW("CRIMSON", "하");
+    BEST("BEST", "최상"),
+    HIGH("HIGH", "상"),
+    MIDDLE("MIDDLE", "중"),
+    LOW("LOW", "하");
 
     private final String code;
     private final String label;

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/ItemQuality.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/ItemQuality.java
@@ -1,0 +1,17 @@
+package com.airfryer.repicka.domain.item.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ItemQuality
+{
+    BEST("CRIMSON", "최상"),
+    HIGH("CRIMSON", "상"),
+    MIDDLE("CRIMSON", "중"),
+    LOW("CRIMSON", "하");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/ItemSize.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/ItemSize.java
@@ -1,0 +1,19 @@
+package com.airfryer.repicka.domain.item.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ItemSize
+{
+    XXL("XXL", "XXL"),
+    XL("XL", "XL"),
+    L("L", "L"),
+    M("M", "M"),
+    S("S", "S"),
+    XS("XS", "XS");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/ProductType.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/ProductType.java
@@ -1,0 +1,23 @@
+package com.airfryer.repicka.domain.item.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ProductType
+{
+    HOCKEY("HOCKEY", "하키"),
+    SOCCER("SOCCER", "축구"),
+    BASKETBALL("BASKETBALL", "농구"),
+    BASEBALL("BASEBALL", "야구"),
+    VARSITY_JACKET("VARSITY_JACKET", "과잠"),
+    ACCESSORY("ACCESSORY", "악세사리"),
+    SELF_MADE("SELF_MADE", "자체 제작"),
+    VINTAGE("VINTAGE", "빈티지"),
+    REFORM("REFORM", "리폼"),
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/TradeMethod.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/TradeMethod.java
@@ -1,0 +1,15 @@
+package com.airfryer.repicka.domain.item.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TradeMethod
+{
+    DIRECT("M", "직거래"),
+    PARCEL("S", "택배거래");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/item/entity/TradeMethod.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/entity/TradeMethod.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum TradeMethod
 {
-    DIRECT("M", "직거래"),
-    PARCEL("S", "택배거래");
+    DIRECT("DIRECT", "직거래"),
+    PARCEL("PARCEL", "택배거래"),
+    DIRECT_AND_PARCEL("DIRECT_AND_PARCEL", "직거래 및 택배거래");
 
     private final String code;
     private final String label;

--- a/src/main/java/com/airfryer/repicka/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/repository/ItemRepository.java
@@ -1,0 +1,7 @@
+package com.airfryer.repicka.domain.item.repository;
+
+import com.airfryer.repicka.domain.item.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/com/airfryer/repicka/domain/item_image/entity/ItemImage.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/entity/ItemImage.java
@@ -29,6 +29,6 @@ public class ItemImage extends BaseEntity
 
     // 이미지 URL
     @NotNull
-    @Column(length = 255)
+    @Column(length = 2100)
     private String imageUrl;
 }

--- a/src/main/java/com/airfryer/repicka/domain/item_image/entity/ItemImage.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/entity/ItemImage.java
@@ -1,0 +1,34 @@
+package com.airfryer.repicka.domain.item_image.entity;
+
+import com.airfryer.repicka.common.entity.BaseEntity;
+import com.airfryer.repicka.domain.item.entity.Item;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "item_image"
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class ItemImage extends BaseEntity
+{
+    // 제품 이미지 식별자
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 제품
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item")
+    private Item item;
+
+    // 이미지 URL
+    @NotNull
+    @Column(length = 255)
+    private String imageUrl;
+}

--- a/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
@@ -1,0 +1,7 @@
+package com.airfryer.repicka.domain.item_image.repository;
+
+import com.airfryer.repicka.domain.item_image.entity.ItemImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
+}

--- a/src/main/java/com/airfryer/repicka/domain/post/entity/Post.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/entity/Post.java
@@ -48,5 +48,6 @@ public class Post extends BaseEntity
 
     // 좋아요 개수
     @NotNull
-    private int likeCount;
+    @Builder.Default
+    private int likeCount = 0;
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/entity/Post.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/entity/Post.java
@@ -44,7 +44,9 @@ public class Post extends BaseEntity
     private int price;
 
     // 보증금
-    private int deposit;
+    @NotNull
+    @Builder.Default
+    private int deposit = 0;
 
     // 좋아요 개수
     @NotNull

--- a/src/main/java/com/airfryer/repicka/domain/post/entity/Post.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/entity/Post.java
@@ -1,0 +1,52 @@
+package com.airfryer.repicka.domain.post.entity;
+
+import com.airfryer.repicka.common.entity.BaseEntity;
+import com.airfryer.repicka.domain.item.entity.Item;
+import com.airfryer.repicka.domain.user.entity.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "post"
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Post extends BaseEntity
+{
+    // 게시글 식별자
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 작성자
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer")
+    private User writer;
+
+    // 제품
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item")
+    private Item item;
+
+    // 게시글 타입
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private PostType postType;
+
+    // 대여료 / 판매값
+    @NotNull
+    private int price;
+
+    // 보증금
+    private int deposit;
+
+    // 좋아요 개수
+    @NotNull
+    private int likeCount;
+}

--- a/src/main/java/com/airfryer/repicka/domain/post/entity/PostType.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/entity/PostType.java
@@ -1,0 +1,15 @@
+package com.airfryer.repicka.domain.post.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PostType
+{
+    RENTAL("RENTAL", "대여"),
+    SALE("SALE", "판매");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.airfryer.repicka.domain.post.repository;
+
+import com.airfryer.repicka.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/airfryer/repicka/domain/post_like/entity/PostLike.java
+++ b/src/main/java/com/airfryer/repicka/domain/post_like/entity/PostLike.java
@@ -1,0 +1,36 @@
+package com.airfryer.repicka.domain.post_like.entity;
+
+import com.airfryer.repicka.common.entity.BaseEntity;
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.user.entity.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "post_like"
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PostLike extends BaseEntity
+{
+    // 게시글 좋아요 식별자
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 사용자
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "liker")
+    private User liker;
+
+    // 게시글
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post")
+    private Post post;
+}

--- a/src/main/java/com/airfryer/repicka/domain/post_like/repository/PostLikeRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/post_like/repository/PostLikeRepository.java
@@ -1,0 +1,7 @@
+package com.airfryer.repicka.domain.post_like.repository;
+
+import com.airfryer.repicka.domain.post_like.entity.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+}

--- a/src/main/java/com/airfryer/repicka/domain/test/controller/TestController.java
+++ b/src/main/java/com/airfryer/repicka/domain/test/controller/TestController.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,7 +25,7 @@ public class TestController
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponseDto.builder()
                         .message("로그인을 수행한 사용자입니다.")
-                        .data(user.getUserId())
+                        .data(user.getId())
                         .build());
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 
 @Entity
 @Table(
-        name = "user",
+        name = "users",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"email", "login_method"})
         }
@@ -18,7 +18,8 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class User extends BaseEntity {
+public class User extends BaseEntity
+{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 사용자 식별자

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 
 @Entity
 @Table(
-        name = "users",
+        name = "user",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"email", "login_method"})
         }
@@ -21,7 +21,7 @@ import java.time.LocalDate;
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long userId; // 사용자 식별자
+    private Long id;    // 사용자 식별자
 
     @NotNull
     private String email; // 이메일

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -21,7 +21,7 @@ import java.time.LocalDate;
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;    // 사용자 식별자
+    private Long id; // 사용자 식별자
 
     @NotNull
     private String email; // 이메일

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -45,7 +45,7 @@ public class User extends BaseEntity
     private String profileImageUrl; // 프로필 이미지 URL
 
     @NotNull
-    private boolean isKoreaUnivVerified; // 고려대 학생 인증 여부
+    private Boolean isKoreaUnivVerified; // 고려대 학생 인증 여부
 
     @Enumerated(EnumType.STRING)
     private Gender gender; // 성별 (F,M)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
 
-  ## database(mariadb) 연동
+  ## database(postgresql) 연동
   datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
+    driver-class-name: org.postgresql.Driver
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
@@ -12,7 +12,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MariaDBDialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
   ## OAuth 설정
   security:

--- a/src/test/java/com/airfryer/repicka/domain/appointment/AppointmentTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/appointment/AppointmentTest.java
@@ -41,7 +41,7 @@ public class AppointmentTest
         assertThat(findAppointment.getRentalDate()).isEqualTo(appointment.getRentalDate());
         assertThat(findAppointment.getReturnDate()).isEqualTo(appointment.getReturnDate());
         assertThat(findAppointment.getPrice()).isEqualTo(appointment.getPrice());
-        assertThat(findAppointment.getDeposit()).isEqualTo(appointment.getDeposit());
+        assertThat(findAppointment.getDeposit()).isEqualTo(appointment.getDeposit()).isEqualTo(0);
         assertThat(findAppointment.getState()).isEqualTo(appointment.getState());
     }
 }

--- a/src/test/java/com/airfryer/repicka/domain/appointment/AppointmentTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/appointment/AppointmentTest.java
@@ -1,0 +1,47 @@
+package com.airfryer.repicka.domain.appointment;
+
+import com.airfryer.repicka.domain.appointment.entity.Appointment;
+import com.airfryer.repicka.domain.appointment.repository.AppointmentRepository;
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.util.CreateEntityUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class AppointmentTest
+{
+    @Autowired AppointmentRepository appointmentRepository;
+
+    @Autowired CreateEntityUtil createEntityUtil;
+
+    @Test
+    @DisplayName("Appointment 엔티티 생성 테스트")
+    void createAppointment()
+    {
+        /// Given
+
+        Appointment appointment = createEntityUtil.createAppointment();
+
+        /// Then
+
+        Appointment findAppointment = appointmentRepository.findById(appointment.getId()).orElse(null);
+
+        assertThat(findAppointment).isNotNull();
+        assertThat(findAppointment.getPost()).isEqualTo(appointment.getPost());
+        assertThat(findAppointment.getOwner()).isEqualTo(appointment.getOwner());
+        assertThat(findAppointment.getBorrower()).isEqualTo(appointment.getBorrower());
+        assertThat(findAppointment.getRentalLocation()).isEqualTo(appointment.getRentalLocation());
+        assertThat(findAppointment.getReturnLocation()).isEqualTo(appointment.getReturnLocation());
+        assertThat(findAppointment.getRentalDate()).isEqualTo(appointment.getRentalDate());
+        assertThat(findAppointment.getReturnDate()).isEqualTo(appointment.getReturnDate());
+        assertThat(findAppointment.getPrice()).isEqualTo(appointment.getPrice());
+        assertThat(findAppointment.getDeposit()).isEqualTo(appointment.getDeposit());
+        assertThat(findAppointment.getState()).isEqualTo(appointment.getState());
+    }
+}

--- a/src/test/java/com/airfryer/repicka/domain/item/ItemTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/item/ItemTest.java
@@ -1,0 +1,79 @@
+package com.airfryer.repicka.domain.item;
+
+import com.airfryer.repicka.domain.item.entity.*;
+import com.airfryer.repicka.domain.item.repository.ItemRepository;
+import com.airfryer.repicka.domain.user.entity.Gender;
+import com.airfryer.repicka.domain.user.entity.LoginMethod;
+import com.airfryer.repicka.domain.user.entity.Role;
+import com.airfryer.repicka.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class ItemTest
+{
+    @Autowired ItemRepository itemRepository;
+
+    @Test
+    @DisplayName("Item 엔티티 생성 테스트")
+    void createItem()
+    {
+        /// Given
+
+        ProductType[] productType = {ProductType.HOCKEY, ProductType.ACCESSORY};
+        ItemSize size = ItemSize.XL;
+        String title = "title";
+        String description = "description";
+        ItemColor color = ItemColor.BLACK;
+        ItemQuality quality = ItemQuality.LOW;
+        String location = "location";
+        TradeMethod tradeMethod = TradeMethod.DIRECT;
+        Boolean canDeal = true;
+        CurrentItemState state = CurrentItemState.AVAILABLE;
+        LocalDateTime repostDate = LocalDateTime.now();
+
+        /// When
+
+        Item item = Item.builder()
+                .productType(productType)
+                .size(size)
+                .title(title)
+                .description(description)
+                .color(color)
+                .quality(quality)
+                .location(location)
+                .tradeMethod(tradeMethod)
+                .canDeal(canDeal)
+                .state(state)
+                .repostDate(repostDate)
+                .build();
+
+        item = itemRepository.save(item);
+
+        /// Then
+
+        Item findItem = itemRepository.findById(item.getId()).orElse(null);
+
+        assertThat(findItem).isNotNull();
+        assertThat(findItem.getProductType()).isEqualTo(productType);
+        assertThat(findItem.getSize()).isEqualTo(size);
+        assertThat(findItem.getTitle()).isEqualTo(title);
+        assertThat(findItem.getDescription()).isEqualTo(description);
+        assertThat(findItem.getColor()).isEqualTo(color);
+        assertThat(findItem.getQuality()).isEqualTo(quality);
+        assertThat(findItem.getLocation()).isEqualTo(location);
+        assertThat(findItem.getTradeMethod()).isEqualTo(tradeMethod);
+        assertThat(findItem.getCanDeal()).isEqualTo(canDeal);
+        assertThat(findItem.getState()).isEqualTo(state);
+        assertThat(findItem.getRepostDate()).isEqualTo(repostDate);
+    }
+}

--- a/src/test/java/com/airfryer/repicka/domain/item/ItemTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/item/ItemTest.java
@@ -39,7 +39,7 @@ public class ItemTest
         Item findItem = itemRepository.findById(item.getId()).orElse(null);
 
         assertThat(findItem).isNotNull();
-        assertThat(findItem.getProductType()).isEqualTo(item.getProductType());
+        assertThat(findItem.getProductTypes()).isEqualTo(item.getProductTypes());
         assertThat(findItem.getSize()).isEqualTo(item.getSize());
         assertThat(findItem.getTitle()).isEqualTo(item.getTitle());
         assertThat(findItem.getDescription()).isEqualTo(item.getDescription());

--- a/src/test/java/com/airfryer/repicka/domain/item/ItemTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/item/ItemTest.java
@@ -6,6 +6,7 @@ import com.airfryer.repicka.domain.user.entity.Gender;
 import com.airfryer.repicka.domain.user.entity.LoginMethod;
 import com.airfryer.repicka.domain.user.entity.Role;
 import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.util.CreateEntityUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,57 +24,31 @@ public class ItemTest
 {
     @Autowired ItemRepository itemRepository;
 
+    @Autowired CreateEntityUtil createEntityUtil;
+
     @Test
     @DisplayName("Item 엔티티 생성 테스트")
     void createItem()
     {
         /// Given
 
-        ProductType[] productType = {ProductType.HOCKEY, ProductType.ACCESSORY};
-        ItemSize size = ItemSize.XL;
-        String title = "title";
-        String description = "description";
-        ItemColor color = ItemColor.BLACK;
-        ItemQuality quality = ItemQuality.LOW;
-        String location = "location";
-        TradeMethod tradeMethod = TradeMethod.DIRECT;
-        Boolean canDeal = true;
-        CurrentItemState state = CurrentItemState.AVAILABLE;
-        LocalDateTime repostDate = LocalDateTime.now();
-
-        /// When
-
-        Item item = Item.builder()
-                .productType(productType)
-                .size(size)
-                .title(title)
-                .description(description)
-                .color(color)
-                .quality(quality)
-                .location(location)
-                .tradeMethod(tradeMethod)
-                .canDeal(canDeal)
-                .state(state)
-                .repostDate(repostDate)
-                .build();
-
-        item = itemRepository.save(item);
+        Item item = createEntityUtil.createItem();
 
         /// Then
 
         Item findItem = itemRepository.findById(item.getId()).orElse(null);
 
         assertThat(findItem).isNotNull();
-        assertThat(findItem.getProductType()).isEqualTo(productType);
-        assertThat(findItem.getSize()).isEqualTo(size);
-        assertThat(findItem.getTitle()).isEqualTo(title);
-        assertThat(findItem.getDescription()).isEqualTo(description);
-        assertThat(findItem.getColor()).isEqualTo(color);
-        assertThat(findItem.getQuality()).isEqualTo(quality);
-        assertThat(findItem.getLocation()).isEqualTo(location);
-        assertThat(findItem.getTradeMethod()).isEqualTo(tradeMethod);
-        assertThat(findItem.getCanDeal()).isEqualTo(canDeal);
-        assertThat(findItem.getState()).isEqualTo(state);
-        assertThat(findItem.getRepostDate()).isEqualTo(repostDate);
+        assertThat(findItem.getProductType()).isEqualTo(item.getProductType());
+        assertThat(findItem.getSize()).isEqualTo(item.getSize());
+        assertThat(findItem.getTitle()).isEqualTo(item.getTitle());
+        assertThat(findItem.getDescription()).isEqualTo(item.getDescription());
+        assertThat(findItem.getColor()).isEqualTo(item.getColor());
+        assertThat(findItem.getQuality()).isEqualTo(item.getQuality());
+        assertThat(findItem.getLocation()).isEqualTo(item.getLocation());
+        assertThat(findItem.getTradeMethod()).isEqualTo(item.getTradeMethod());
+        assertThat(findItem.getCanDeal()).isEqualTo(item.getCanDeal());
+        assertThat(findItem.getState()).isEqualTo(item.getState());
+        assertThat(findItem.getRepostDate()).isEqualTo(item.getRepostDate());
     }
 }

--- a/src/test/java/com/airfryer/repicka/domain/item_image/ItemImageTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/item_image/ItemImageTest.java
@@ -1,0 +1,39 @@
+package com.airfryer.repicka.domain.item_image;
+
+import com.airfryer.repicka.domain.item.entity.Item;
+import com.airfryer.repicka.domain.item_image.entity.ItemImage;
+import com.airfryer.repicka.domain.item_image.repository.ItemImageRepository;
+import com.airfryer.repicka.util.CreateEntityUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class ItemImageTest
+{
+    @Autowired ItemImageRepository itemImageRepository;
+
+    @Autowired CreateEntityUtil createEntityUtil;
+
+    @Test
+    @DisplayName("ItemImage 엔티티 생성 테스트")
+    void createItemImage()
+    {
+        /// Given
+
+        ItemImage itemImage = createEntityUtil.createItemImage();
+
+        /// Then
+
+        ItemImage findItemImage = itemImageRepository.findById(itemImage.getId()).orElse(null);
+
+        assertThat(findItemImage).isNotNull();
+        assertThat(findItemImage.getItem()).isEqualTo(itemImage.getItem());
+        assertThat(findItemImage.getImageUrl()).isEqualTo(itemImage.getImageUrl());
+    }
+}

--- a/src/test/java/com/airfryer/repicka/domain/post/PostTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/post/PostTest.java
@@ -38,6 +38,6 @@ public class PostTest
         assertThat(findPost.getPostType()).isEqualTo(post.getPostType());
         assertThat(findPost.getPrice()).isEqualTo(post.getPrice());
         assertThat(findPost.getDeposit()).isEqualTo(post.getDeposit());
-        assertThat(findPost.getLikeCount()).isEqualTo(post.getLikeCount());
+        assertThat(findPost.getLikeCount()).isEqualTo(post.getLikeCount()).isEqualTo(0);
     }
 }

--- a/src/test/java/com/airfryer/repicka/domain/post/PostTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/post/PostTest.java
@@ -1,0 +1,43 @@
+package com.airfryer.repicka.domain.post;
+
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post.repository.PostRepository;
+import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.util.CreateEntityUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class PostTest
+{
+    @Autowired PostRepository postRepository;
+
+    @Autowired CreateEntityUtil createEntityUtil;
+
+    @Test
+    @DisplayName("Post 엔티티 생성 테스트")
+    void createPost()
+    {
+        /// Given
+
+        Post post = createEntityUtil.createPost();
+
+        /// Then
+
+        Post findPost = postRepository.findById(post.getId()).orElse(null);
+
+        assertThat(findPost).isNotNull();
+        assertThat(findPost.getWriter()).isEqualTo(post.getWriter());
+        assertThat(findPost.getItem()).isEqualTo(post.getItem());
+        assertThat(findPost.getPostType()).isEqualTo(post.getPostType());
+        assertThat(findPost.getPrice()).isEqualTo(post.getPrice());
+        assertThat(findPost.getDeposit()).isEqualTo(post.getDeposit());
+        assertThat(findPost.getLikeCount()).isEqualTo(post.getLikeCount());
+    }
+}

--- a/src/test/java/com/airfryer/repicka/domain/post/PostTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/post/PostTest.java
@@ -37,7 +37,7 @@ public class PostTest
         assertThat(findPost.getItem()).isEqualTo(post.getItem());
         assertThat(findPost.getPostType()).isEqualTo(post.getPostType());
         assertThat(findPost.getPrice()).isEqualTo(post.getPrice());
-        assertThat(findPost.getDeposit()).isEqualTo(post.getDeposit());
+        assertThat(findPost.getDeposit()).isEqualTo(post.getDeposit()).isEqualTo(0);
         assertThat(findPost.getLikeCount()).isEqualTo(post.getLikeCount()).isEqualTo(0);
     }
 }

--- a/src/test/java/com/airfryer/repicka/domain/post_like/PostLikeTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/post_like/PostLikeTest.java
@@ -1,0 +1,39 @@
+package com.airfryer.repicka.domain.post_like;
+
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post_like.entity.PostLike;
+import com.airfryer.repicka.domain.post_like.repository.PostLikeRepository;
+import com.airfryer.repicka.util.CreateEntityUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class PostLikeTest
+{
+    @Autowired PostLikeRepository postLikeRepository;
+
+    @Autowired CreateEntityUtil createEntityUtil;
+
+    @Test
+    @DisplayName("PostLike 엔티티 생성 테스트")
+    void createPostLike()
+    {
+        /// Given
+
+        PostLike postLike = createEntityUtil.createPostLike();
+
+        /// Then
+
+        PostLike findPostLike = postLikeRepository.findById(postLike.getId()).orElse(null);
+
+        assertThat(findPostLike).isNotNull();
+        assertThat(findPostLike.getLiker()).isEqualTo(postLike.getLiker());
+        assertThat(findPostLike.getPost()).isEqualTo(postLike.getPost());
+    }
+}

--- a/src/test/java/com/airfryer/repicka/domain/user/UserTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/user/UserTest.java
@@ -1,0 +1,83 @@
+package com.airfryer.repicka.domain.user;
+
+import com.airfryer.repicka.domain.user.entity.Gender;
+import com.airfryer.repicka.domain.user.entity.LoginMethod;
+import com.airfryer.repicka.domain.user.entity.Role;
+import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class UserTest
+{
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("User 엔티티 생성 테스트")
+    void createUser()
+    {
+        /// Given
+
+        String email = "test@naver.com";
+        String nickname = "Test";
+        LoginMethod loginMethod = LoginMethod.GOOGLE;
+        String oauthId = "0000000000";
+        Role role = Role.USER;
+        String profileImageUrl = "/프로필-이미지-기본경로";
+        Boolean isKoreanUnivVerified = false;
+        Gender gender = Gender.MALE;
+        Integer height = 180;
+        Integer weight = 70;
+        String fcmToken = "fcmToken";
+        int todayPostCount = 0;
+        LocalDate lastAccessDate = LocalDate.now();
+
+        /// When
+
+        User user = User.builder()
+                .email(email)
+                .nickname(nickname)
+                .loginMethod(loginMethod)
+                .oauthId(oauthId)
+                .role(role)
+                .profileImageUrl(profileImageUrl)
+                .isKoreaUnivVerified(isKoreanUnivVerified)
+                .gender(gender)
+                .height(height)
+                .weight(weight)
+                .fcmToken(fcmToken)
+                .todayPostCount(todayPostCount)
+                .lastAccessDate(lastAccessDate)
+                .build();
+
+        userRepository.save(user);
+
+        /// Then
+
+        User findUser = userRepository.findByOauthIdAndLoginMethod(oauthId, loginMethod).get();
+
+        assertThat(findUser).isNotNull();
+        assertThat(findUser.getEmail()).isEqualTo(email);
+        assertThat(findUser.getNickname()).isEqualTo(nickname);
+        assertThat(findUser.getLoginMethod()).isEqualTo(loginMethod);
+        assertThat(findUser.getOauthId()).isEqualTo(oauthId);
+        assertThat(findUser.getRole()).isEqualTo(role);
+        assertThat(findUser.getProfileImageUrl()).isEqualTo(profileImageUrl);
+        assertThat(findUser.getIsKoreaUnivVerified()).isEqualTo(isKoreanUnivVerified);
+        assertThat(findUser.getGender()).isEqualTo(gender);
+        assertThat(findUser.getHeight()).isEqualTo(height);
+        assertThat(findUser.getWeight()).isEqualTo(weight);
+        assertThat(findUser.getFcmToken()).isEqualTo(fcmToken);
+        assertThat(findUser.getTodayPostCount()).isEqualTo(todayPostCount);
+        assertThat(findUser.getLastAccessDate()).isEqualTo(lastAccessDate);
+    }
+}

--- a/src/test/java/com/airfryer/repicka/domain/user/UserTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/user/UserTest.java
@@ -5,6 +5,7 @@ import com.airfryer.repicka.domain.user.entity.LoginMethod;
 import com.airfryer.repicka.domain.user.entity.Role;
 import com.airfryer.repicka.domain.user.entity.User;
 import com.airfryer.repicka.domain.user.repository.UserRepository;
+import com.airfryer.repicka.util.CreateEntityUtil;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,63 +21,33 @@ public class UserTest
 {
     @Autowired UserRepository userRepository;
 
+    @Autowired CreateEntityUtil createEntityUtil;
+
     @Test
     @DisplayName("User 엔티티 생성 테스트")
     void createUser()
     {
         /// Given
 
-        String email = "test@naver.com";
-        String nickname = "Test";
-        LoginMethod loginMethod = LoginMethod.GOOGLE;
-        String oauthId = "0000000000";
-        Role role = Role.USER;
-        String profileImageUrl = "/프로필-이미지-기본경로";
-        Boolean isKoreanUnivVerified = false;
-        Gender gender = Gender.MALE;
-        Integer height = 180;
-        Integer weight = 70;
-        String fcmToken = "fcmToken";
-        int todayPostCount = 0;
-        LocalDate lastAccessDate = LocalDate.now();
-
-        /// When
-
-        User user = User.builder()
-                .email(email)
-                .nickname(nickname)
-                .loginMethod(loginMethod)
-                .oauthId(oauthId)
-                .role(role)
-                .profileImageUrl(profileImageUrl)
-                .isKoreaUnivVerified(isKoreanUnivVerified)
-                .gender(gender)
-                .height(height)
-                .weight(weight)
-                .fcmToken(fcmToken)
-                .todayPostCount(todayPostCount)
-                .lastAccessDate(lastAccessDate)
-                .build();
-
-        userRepository.save(user);
+        User user = createEntityUtil.createUser();
 
         /// Then
 
-        User findUser = userRepository.findByOauthIdAndLoginMethod(oauthId, loginMethod).get();
+        User findUser = userRepository.findByOauthIdAndLoginMethod(user.getOauthId(), user.getLoginMethod()).orElse(null);
 
         assertThat(findUser).isNotNull();
-        assertThat(findUser.getEmail()).isEqualTo(email);
-        assertThat(findUser.getNickname()).isEqualTo(nickname);
-        assertThat(findUser.getLoginMethod()).isEqualTo(loginMethod);
-        assertThat(findUser.getOauthId()).isEqualTo(oauthId);
-        assertThat(findUser.getRole()).isEqualTo(role);
-        assertThat(findUser.getProfileImageUrl()).isEqualTo(profileImageUrl);
-        assertThat(findUser.getIsKoreaUnivVerified()).isEqualTo(isKoreanUnivVerified);
-        assertThat(findUser.getGender()).isEqualTo(gender);
-        assertThat(findUser.getHeight()).isEqualTo(height);
-        assertThat(findUser.getWeight()).isEqualTo(weight);
-        assertThat(findUser.getFcmToken()).isEqualTo(fcmToken);
-        assertThat(findUser.getTodayPostCount()).isEqualTo(todayPostCount);
-        assertThat(findUser.getLastAccessDate()).isEqualTo(lastAccessDate);
+        assertThat(findUser.getEmail()).isEqualTo(user.getEmail());
+        assertThat(findUser.getNickname()).isEqualTo(user.getNickname());
+        assertThat(findUser.getLoginMethod()).isEqualTo(user.getLoginMethod());
+        assertThat(findUser.getOauthId()).isEqualTo(user.getOauthId());
+        assertThat(findUser.getRole()).isEqualTo(user.getRole());
+        assertThat(findUser.getProfileImageUrl()).isEqualTo(user.getProfileImageUrl());
+        assertThat(findUser.getIsKoreaUnivVerified()).isEqualTo(user.getIsKoreaUnivVerified());
+        assertThat(findUser.getGender()).isEqualTo(user.getGender());
+        assertThat(findUser.getHeight()).isEqualTo(user.getHeight());
+        assertThat(findUser.getWeight()).isEqualTo(user.getWeight());
+        assertThat(findUser.getFcmToken()).isEqualTo(user.getFcmToken());
+        assertThat(findUser.getTodayPostCount()).isEqualTo(user.getTodayPostCount());
+        assertThat(findUser.getLastAccessDate()).isEqualTo(user.getLastAccessDate());
     }
 }

--- a/src/test/java/com/airfryer/repicka/domain/user/UserTest.java
+++ b/src/test/java/com/airfryer/repicka/domain/user/UserTest.java
@@ -18,8 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional
 public class UserTest
 {
-    @Autowired
-    UserRepository userRepository;
+    @Autowired UserRepository userRepository;
 
     @Test
     @DisplayName("User 엔티티 생성 테스트")

--- a/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
+++ b/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
@@ -1,5 +1,8 @@
 package com.airfryer.repicka.util;
 
+import com.airfryer.repicka.domain.appointment.entity.Appointment;
+import com.airfryer.repicka.domain.appointment.entity.AppointmentState;
+import com.airfryer.repicka.domain.appointment.repository.AppointmentRepository;
 import com.airfryer.repicka.domain.item.entity.*;
 import com.airfryer.repicka.domain.item.repository.ItemRepository;
 import com.airfryer.repicka.domain.item_image.entity.ItemImage;
@@ -32,27 +35,29 @@ public class CreateEntityUtil
     private final ItemImageRepository itemImageRepository;
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
+    private final AppointmentRepository appointmentRepository;
 
-    public User createUser() {
-        return userRepository.findByOauthIdAndLoginMethod("test@naver.com", LoginMethod.GOOGLE)
-                .orElseGet(() -> {
-                    User user = User.builder()
-                            .email("test" + UUID.randomUUID() + "@naver.com")
-                            .nickname("Test")
-                            .loginMethod(LoginMethod.GOOGLE)
-                            .oauthId("0000000000")
-                            .role(Role.USER)
-                            .profileImageUrl("/프로필-이미지-기본경로")
-                            .isKoreaUnivVerified(false)
-                            .gender(Gender.MALE)
-                            .height(180)
-                            .weight(70)
-                            .fcmToken("fcmToken")
-                            .todayPostCount(0)
-                            .lastAccessDate(LocalDate.now())
-                            .build();
-                    return userRepository.save(user);
-                });
+    public User createUser()
+    {
+        User user = User.builder()
+                .email("test" + UUID.randomUUID() + "@naver.com")
+                .nickname("Test")
+                .loginMethod(LoginMethod.GOOGLE)
+                .oauthId("0000000000")
+                .role(Role.USER)
+                .profileImageUrl("/프로필-이미지-기본경로")
+                .isKoreaUnivVerified(false)
+                .gender(Gender.MALE)
+                .height(180)
+                .weight(70)
+                .fcmToken("fcmToken")
+                .todayPostCount(0)
+                .lastAccessDate(LocalDate.now())
+                .build();
+
+        user = userRepository.save(user);
+
+        return user;
     }
 
     public Item createItem()
@@ -114,5 +119,25 @@ public class CreateEntityUtil
         postLike = postLikeRepository.save(postLike);
 
         return postLike;
+    }
+
+    public Appointment createAppointment()
+    {
+        Appointment appointment = Appointment.builder()
+                .post(createPost())
+                .owner(createUser())
+                .borrower(createUser())
+                .rentalLocation("rentalLocation")
+                .returnLocation("returnLocation")
+                .rentalDate(LocalDateTime.now())
+                .returnDate(LocalDateTime.now().plusDays(1))
+                .price(10000)
+                .deposit(10000)
+                .state(AppointmentState.SUCCESS)
+                .build();
+
+        appointment = appointmentRepository.save(appointment);
+
+        return appointment;
     }
 }

--- a/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
+++ b/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
@@ -7,6 +7,8 @@ import com.airfryer.repicka.domain.item_image.repository.ItemImageRepository;
 import com.airfryer.repicka.domain.post.entity.Post;
 import com.airfryer.repicka.domain.post.entity.PostType;
 import com.airfryer.repicka.domain.post.repository.PostRepository;
+import com.airfryer.repicka.domain.post_like.entity.PostLike;
+import com.airfryer.repicka.domain.post_like.repository.PostLikeRepository;
 import com.airfryer.repicka.domain.user.entity.Gender;
 import com.airfryer.repicka.domain.user.entity.LoginMethod;
 import com.airfryer.repicka.domain.user.entity.Role;
@@ -19,6 +21,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -28,28 +31,28 @@ public class CreateEntityUtil
     private final ItemRepository itemRepository;
     private final ItemImageRepository itemImageRepository;
     private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
 
-    public User createUser()
-    {
-        User user = User.builder()
-                .email("test@naver.com")
-                .nickname("Test")
-                .loginMethod(LoginMethod.GOOGLE)
-                .oauthId("0000000000")
-                .role(Role.USER)
-                .profileImageUrl("/프로필-이미지-기본경로")
-                .isKoreaUnivVerified(false)
-                .gender(Gender.MALE)
-                .height(180)
-                .weight(70)
-                .fcmToken("fcmToken")
-                .todayPostCount(0)
-                .lastAccessDate(LocalDate.now())
-                .build();
-
-        user = userRepository.save(user);
-
-        return user;
+    public User createUser() {
+        return userRepository.findByOauthIdAndLoginMethod("test@naver.com", LoginMethod.GOOGLE)
+                .orElseGet(() -> {
+                    User user = User.builder()
+                            .email("test" + UUID.randomUUID() + "@naver.com")
+                            .nickname("Test")
+                            .loginMethod(LoginMethod.GOOGLE)
+                            .oauthId("0000000000")
+                            .role(Role.USER)
+                            .profileImageUrl("/프로필-이미지-기본경로")
+                            .isKoreaUnivVerified(false)
+                            .gender(Gender.MALE)
+                            .height(180)
+                            .weight(70)
+                            .fcmToken("fcmToken")
+                            .todayPostCount(0)
+                            .lastAccessDate(LocalDate.now())
+                            .build();
+                    return userRepository.save(user);
+                });
     }
 
     public Item createItem()
@@ -99,5 +102,17 @@ public class CreateEntityUtil
         post = postRepository.save(post);
 
         return post;
+    }
+
+    public PostLike createPostLike()
+    {
+        PostLike postLike = PostLike.builder()
+                .liker(createUser())
+                .post(createPost())
+                .build();
+
+        postLike = postLikeRepository.save(postLike);
+
+        return postLike;
     }
 }

--- a/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
+++ b/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
@@ -101,7 +101,6 @@ public class CreateEntityUtil
                 .postType(PostType.RENTAL)
                 .price(10000)
                 .deposit(10000)
-                .likeCount(0)
                 .build();
 
         post = postRepository.save(post);

--- a/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
+++ b/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
@@ -4,6 +4,9 @@ import com.airfryer.repicka.domain.item.entity.*;
 import com.airfryer.repicka.domain.item.repository.ItemRepository;
 import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import com.airfryer.repicka.domain.item_image.repository.ItemImageRepository;
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post.entity.PostType;
+import com.airfryer.repicka.domain.post.repository.PostRepository;
 import com.airfryer.repicka.domain.user.entity.Gender;
 import com.airfryer.repicka.domain.user.entity.LoginMethod;
 import com.airfryer.repicka.domain.user.entity.Role;
@@ -24,6 +27,7 @@ public class CreateEntityUtil
     private final UserRepository userRepository;
     private final ItemRepository itemRepository;
     private final ItemImageRepository itemImageRepository;
+    private final PostRepository postRepository;
 
     public User createUser()
     {
@@ -79,5 +83,21 @@ public class CreateEntityUtil
         itemImage = itemImageRepository.save(itemImage);
 
         return itemImage;
+    }
+
+    public Post createPost()
+    {
+        Post post = Post.builder()
+                .writer(createUser())
+                .item(createItem())
+                .postType(PostType.RENTAL)
+                .price(10000)
+                .deposit(10000)
+                .likeCount(0)
+                .build();
+
+        post = postRepository.save(post);
+
+        return post;
     }
 }

--- a/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
+++ b/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
@@ -100,7 +100,6 @@ public class CreateEntityUtil
                 .item(createItem())
                 .postType(PostType.RENTAL)
                 .price(10000)
-                .deposit(10000)
                 .build();
 
         post = postRepository.save(post);
@@ -131,7 +130,6 @@ public class CreateEntityUtil
                 .rentalDate(LocalDateTime.now())
                 .returnDate(LocalDateTime.now().plusDays(1))
                 .price(10000)
-                .deposit(10000)
                 .state(AppointmentState.SUCCESS)
                 .build();
 

--- a/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
+++ b/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
@@ -1,0 +1,70 @@
+package com.airfryer.repicka.util;
+
+import com.airfryer.repicka.domain.item.entity.*;
+import com.airfryer.repicka.domain.item.repository.ItemRepository;
+import com.airfryer.repicka.domain.item_image.repository.ItemImageRepository;
+import com.airfryer.repicka.domain.user.entity.Gender;
+import com.airfryer.repicka.domain.user.entity.LoginMethod;
+import com.airfryer.repicka.domain.user.entity.Role;
+import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.domain.user.repository.UserRepository;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class CreateEntityUtil
+{
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final ItemImageRepository itemImageRepository;
+
+    public User createUser()
+    {
+        User user = User.builder()
+                .email("test@naver.com")
+                .nickname("Test")
+                .loginMethod(LoginMethod.GOOGLE)
+                .oauthId("0000000000")
+                .role(Role.USER)
+                .profileImageUrl("/프로필-이미지-기본경로")
+                .isKoreaUnivVerified(false)
+                .gender(Gender.MALE)
+                .height(180)
+                .weight(70)
+                .fcmToken("fcmToken")
+                .todayPostCount(0)
+                .lastAccessDate(LocalDate.now())
+                .build();
+
+        user = userRepository.save(user);
+
+        return user;
+    }
+
+    public Item createItem()
+    {
+        Item item = Item.builder()
+                .productType(new ProductType[]{ProductType.HOCKEY, ProductType.ACCESSORY})
+                .size(ItemSize.XL)
+                .title("title")
+                .description("description")
+                .color(ItemColor.BLACK)
+                .quality(ItemQuality.LOW)
+                .location("location")
+                .tradeMethod(TradeMethod.DIRECT)
+                .canDeal(true)
+                .state(CurrentItemState.AVAILABLE)
+                .repostDate(LocalDateTime.now())
+                .build();
+
+        item = itemRepository.save(item);
+
+        return item;
+    }
+}

--- a/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
+++ b/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
@@ -63,7 +63,7 @@ public class CreateEntityUtil
     public Item createItem()
     {
         Item item = Item.builder()
-                .productType(new ProductType[]{ProductType.HOCKEY, ProductType.ACCESSORY})
+                .productTypes(new ProductType[]{ProductType.HOCKEY, ProductType.ACCESSORY})
                 .size(ItemSize.XL)
                 .title("title")
                 .description("description")

--- a/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
+++ b/src/test/java/com/airfryer/repicka/util/CreateEntityUtil.java
@@ -2,6 +2,7 @@ package com.airfryer.repicka.util;
 
 import com.airfryer.repicka.domain.item.entity.*;
 import com.airfryer.repicka.domain.item.repository.ItemRepository;
+import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import com.airfryer.repicka.domain.item_image.repository.ItemImageRepository;
 import com.airfryer.repicka.domain.user.entity.Gender;
 import com.airfryer.repicka.domain.user.entity.LoginMethod;
@@ -66,5 +67,17 @@ public class CreateEntityUtil
         item = itemRepository.save(item);
 
         return item;
+    }
+
+    public ItemImage createItemImage()
+    {
+        ItemImage itemImage = ItemImage.builder()
+                .item(createItem())
+                .imageUrl("/이미지-경로")
+                .build();
+
+        itemImage = itemImageRepository.save(itemImage);
+
+        return itemImage;
     }
 }


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#11 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
- 메인 DB를 MariaDB에서 PostgreSQL로 전환하였습니다.
- 다음 5가지 엔티티를 구현하였습니다.
  - item (제품)
  - item_image (제품 이미지)
  - post (게시글)
  - post_like (게시글 좋아요)
  - appointment (약속)
- 배열 컬럼을 사용하기 위해 hypersistence-utils 라이브러리를 사용하였습니다.
- 각각의 엔티티 생성이 제대로 되는지 확인하는 테스트 코드를 추가하였습니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
- PostgreSQL은 "user"을 테이블명이나 컬럼명으로 사용할 수 없더라구요 신기방기함

<br>