### PR TITLE
[FEAT#13]: 게시글 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### QueryDSL ###
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
 	// Spring Data JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	// Querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	// 데이터 검증
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
@@ -64,4 +70,19 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// QueryDSL 관련 설정
+def querydslDir = 'src/main/generated'
+
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+clean {
+	delete file(querydslDir)
 }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -477,4 +477,8 @@ public class AppointmentService
 
         return firstSaleAvailableDate;
     }
+
+    public boolean isPostAvailableOnDate(Long postId, LocalDateTime date) {
+        return appointmentRepository.findListOverlappingWithPeriod(postId, AppointmentState.CONFIRMED, date, date).isEmpty();
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/item/ItemService.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/ItemService.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 public class ItemService {
     private final ItemRepository itemRepository;
 
-    // question: MapStruct와 set을 사용 or 정적 팩토리 메서드 or 지금 방법 뭐가 나을까요?
     @Transactional
     public Item createItem(CreateItemReq itemDetail) {
         Item item = Item.builder()
@@ -27,7 +26,7 @@ public class ItemService {
                 .location(itemDetail.getLocation().trim())
                 .tradeMethod(itemDetail.getTradeMethod())
                 .canDeal(itemDetail.getCanDeal())
-                .state(itemDetail.getState())
+                .state(CurrentItemState.AVAILABLE)
                 .repostDate(LocalDateTime.now())
                 .build();
 

--- a/src/main/java/com/airfryer/repicka/domain/item/dto/CreateItemReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/dto/CreateItemReq.java
@@ -9,29 +9,26 @@ import lombok.Getter;
 @Getter
 public class CreateItemReq {
     @NotNull(message = "타입을 입력해주세요.")
-    private ProductType[] productTypes = new ProductType[2];
+    private ProductType[] productTypes = new ProductType[2]; // 제품 타입
 
     @NotNull(message = "사이즈를 입력해주세요.")
-    private ItemSize size;
+    private ItemSize size; // 제품 사이즈
+
+    private ItemColor color; // 제품 색상
+
+    private ItemQuality quality; // 제품 품질
 
     @Size(max = 255, message = "제목은 최대 255자까지 입력할 수 있습니다.")
     @NotBlank(message = "제목을 입력해주세요.")
-    private String title;
+    private String title; // 제목
 
-    private String description;
-
-    private ItemColor color;
-
-    private ItemQuality quality;
+    private String description; // 설명
 
     @Size(max = 255, message = "장소는 최대 255자까지 입력할 수 있습니다.")
-    private String location;
+    private String location; // 장소
 
-    private TradeMethod tradeMethod;
+    private TradeMethod tradeMethod; // 거래 방식
 
     @NotNull(message = "가격 제시 가능 여부를 입력해주세요.")
-    private Boolean canDeal;
-
-    @NotNull(message = "제품 상태를 입력해주세요.")
-    private CurrentItemState state;
+    private Boolean canDeal; // 가격 제시 여부
 }

--- a/src/main/java/com/airfryer/repicka/domain/item_image/ItemImageService.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/ItemImageService.java
@@ -23,7 +23,7 @@ public class ItemImageService {
         int order = 1;
         for (String url: urls) {
             ItemImage itemImage = ItemImage.builder()
-                    .order(order++)
+                    .displayOrder(order++)
                     .item(item)
                     .imageUrl(url)
                     .build();
@@ -37,7 +37,7 @@ public class ItemImageService {
     }
 
     public ItemImage getThumbnail(Item item) {
-        return itemImageRepository.findByOrderAndItemId(1, item.getId());
+        return itemImageRepository.findByDisplayOrderAndItemId(1, item.getId());
     }
 
     public List<ItemImage> getItemImages(Item item) {

--- a/src/main/java/com/airfryer/repicka/domain/item_image/ItemImageService.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/ItemImageService.java
@@ -37,6 +37,10 @@ public class ItemImageService {
     }
 
     public ItemImage getThumbnail(Item item) {
-        return itemImageRepository.findByOrderAndItem_id(1, item.getId());
+        return itemImageRepository.findByOrderAndItemId(1, item.getId());
+    }
+
+    public List<ItemImage> getItemImages(Item item) {
+        return itemImageRepository.findAllByItemId(item.getId());
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/item_image/ItemImageService.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/ItemImageService.java
@@ -20,8 +20,10 @@ public class ItemImageService {
     public List<ItemImage> createItemImage(String[] urls, Item item) {
         List<ItemImage> itemImages = new ArrayList<>();
         // TODO: image to url로 변환을 여기에서 처리하거나 s3 서비스에서 처리
+        int order = 1;
         for (String url: urls) {
             ItemImage itemImage = ItemImage.builder()
+                    .order(order++)
                     .item(item)
                     .imageUrl(url)
                     .build();
@@ -32,5 +34,9 @@ public class ItemImageService {
         itemImages = itemImageRepository.saveAll(itemImages);
 
         return itemImages;
+    }
+
+    public ItemImage getThumbnail(Item item) {
+        return itemImageRepository.findByOrderAndItem_id(1, item.getId());
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/item_image/entity/ItemImage.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/entity/ItemImage.java
@@ -21,6 +21,10 @@ public class ItemImage extends BaseEntity
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 사진 순서
+    @NotNull
+    private Integer order;
+
     // 제품
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/airfryer/repicka/domain/item_image/entity/ItemImage.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/entity/ItemImage.java
@@ -23,7 +23,7 @@ public class ItemImage extends BaseEntity
 
     // 사진 순서
     @NotNull
-    private Integer order;
+    private Integer displayOrder;
 
     // 제품
     @NotNull

--- a/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
@@ -3,8 +3,13 @@ package com.airfryer.repicka.domain.item_image.repository;
 import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ItemImageRepository extends JpaRepository<ItemImage, Long>
 {
     // 상품 별 대표 이미지 찾기
-    ItemImage findByOrderAndItem_id(Integer order, Long id);
+    ItemImage findByOrderAndItemId(Integer order, Long itemId);;
+
+    // 상품 별 이미지 목록 찾기
+    List<ItemImage> findAllByItemId(Long itemId);
 }

--- a/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
@@ -3,5 +3,8 @@ package com.airfryer.repicka.domain.item_image.repository;
 import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
+public interface ItemImageRepository extends JpaRepository<ItemImage, Long>
+{
+    // 상품 별 대표 이미지 찾기
+    ItemImage findByOrderAndItem_id(Integer order, Long id);
 }

--- a/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface ItemImageRepository extends JpaRepository<ItemImage, Long>
 {
     // 상품 별 대표 이미지 찾기
-    ItemImage findByOrderAndItemId(Integer order, Long itemId);;
+    ItemImage findByDisplayOrderAndItemId(Integer displayOrder, Long itemId);
 
     // 상품 별 이미지 목록 찾기
     List<ItemImage> findAllByItemId(Long itemId);

--- a/src/main/java/com/airfryer/repicka/domain/post/PostController.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/PostController.java
@@ -4,6 +4,8 @@ import com.airfryer.repicka.common.response.SuccessResponseDto;
 import com.airfryer.repicka.common.security.oauth2.CustomOAuth2User;
 import com.airfryer.repicka.domain.post.dto.CreatePostReq;
 import com.airfryer.repicka.domain.post.dto.PostDetailRes;
+import com.airfryer.repicka.domain.post.dto.PostPreviewRes;
+import com.airfryer.repicka.domain.post.dto.SearchPostReq;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -11,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +36,18 @@ public class PostController {
                 .body(SuccessResponseDto.builder()
                         .message("게시글을 성공적으로 생성하였습니다.")
                         .data(postDetailResList)
+                        .build());
+    }
+
+    @GetMapping("/search")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<SuccessResponseDto> searchPostList(@Valid @RequestBody SearchPostReq req) {
+        List<PostPreviewRes> postPreviewResList = postService.searchPostList(req);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("조건에 따른 게시글 목록을 성공적으로 조회하였습니다.")
+                        .data(postPreviewResList)
                         .build());
     }
 

--- a/src/main/java/com/airfryer/repicka/domain/post/PostController.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/PostController.java
@@ -13,10 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -36,6 +33,18 @@ public class PostController {
                 .body(SuccessResponseDto.builder()
                         .message("게시글을 성공적으로 생성하였습니다.")
                         .data(postDetailResList)
+                        .build());
+    }
+
+    @GetMapping("/{postId}")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<SuccessResponseDto> getPostDetail(@PathVariable Long postId) {
+        PostDetailRes postDetailRes = postService.getPostDetail(postId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("게시글 상세 내용을 성공적으로 조회하였습니다.")
+                        .data(postDetailRes)
                         .build());
     }
 

--- a/src/main/java/com/airfryer/repicka/domain/post/PostController.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/PostController.java
@@ -8,6 +8,7 @@ import com.airfryer.repicka.domain.post.dto.PostPreviewRes;
 import com.airfryer.repicka.domain.post.dto.SearchPostReq;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -38,7 +39,7 @@ public class PostController {
 
     @GetMapping("/{postId}")
     @PreAuthorize("permitAll()")
-    public ResponseEntity<SuccessResponseDto> getPostDetail(@PathVariable Long postId) {
+    public ResponseEntity<SuccessResponseDto> getPostDetail(@PathVariable(value="postId") Long postId) {
         PostDetailRes postDetailRes = postService.getPostDetail(postId);
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/airfryer/repicka/domain/post/PostService.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/PostService.java
@@ -63,9 +63,9 @@ public class PostService {
 
     // 게시글 목록 검색
     @Transactional(readOnly = true)
-    public List<PostPreviewRes> getPostList(SearchPostReq condition) {
+    public List<PostPreviewRes> searchPostList(SearchPostReq condition) {
         // 태그로 게시글 리스트 찾기
-        List<Post> posts = postRepository.searchPostsByTags(condition);
+        List<Post> posts = postRepository.findPostsByCondition(condition);
 
         // 게시글 정보 PostPreviewRes로 정제
         List<PostPreviewRes> postPreviewResList = new ArrayList<>();

--- a/src/main/java/com/airfryer/repicka/domain/post/PostService.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/PostService.java
@@ -84,7 +84,7 @@ public class PostService {
         // 게시글 정보 PostPreviewRes로 정제
         List<PostPreviewRes> postPreviewResList = new ArrayList<>();
         for (Post post : posts) {
-            boolean isAvailable = appointmentService.isPostAvailableOnDate(post.getId(), condition.getRentalDate()); // 원하는 날짜에 대여나 구매 가능 여부
+            boolean isAvailable = appointmentService.isPostAvailableOnDate(post.getId(), condition.getDate()); // 원하는 날짜에 대여나 구매 가능 여부
             ItemImage itemImage = itemImageService.getThumbnail(post.getItem()); // 대표 사진
             PostPreviewRes postPreviewRes = PostPreviewRes.from(post, itemImage, isAvailable);
             postPreviewResList.add(postPreviewRes);

--- a/src/main/java/com/airfryer/repicka/domain/post/PostService.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/PostService.java
@@ -2,7 +2,6 @@ package com.airfryer.repicka.domain.post;
 
 import com.airfryer.repicka.common.exception.CustomException;
 import com.airfryer.repicka.common.exception.CustomExceptionCode;
-import com.airfryer.repicka.domain.appointment.entity.AppointmentState;
 import com.airfryer.repicka.domain.appointment.service.AppointmentService;
 import com.airfryer.repicka.domain.item.ItemService;
 import com.airfryer.repicka.domain.item.entity.Item;
@@ -42,12 +41,12 @@ public class PostService {
         // 게시글 타입에 따라 저장
         List<Post> posts = new ArrayList<>();
 
-        for (PostType postType: postDetail.getPostType()) {
+        for (PostType postType: postDetail.getPostTypes()) {
             Post post = Post.builder()
                     .writer(user)
                     .item(item)
                     .postType(postType)
-                    .price(postDetail.getPrice())
+                    .price(postType == PostType.RENTAL ? postDetail.getRentalFee() : postDetail.getSalePrice())
                     .deposit(postType == PostType.RENTAL ? postDetail.getDeposit() : 0)
                     .build();
 

--- a/src/main/java/com/airfryer/repicka/domain/post/PostService.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/PostService.java
@@ -6,6 +6,8 @@ import com.airfryer.repicka.domain.item_image.ItemImageService;
 import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import com.airfryer.repicka.domain.post.dto.CreatePostReq;
 import com.airfryer.repicka.domain.post.dto.PostDetailRes;
+import com.airfryer.repicka.domain.post.dto.PostPreviewRes;
+import com.airfryer.repicka.domain.post.dto.SearchPostReq;
 import com.airfryer.repicka.domain.post.entity.Post;
 import com.airfryer.repicka.domain.post.entity.PostType;
 import com.airfryer.repicka.domain.post.repository.PostRepository;
@@ -25,6 +27,7 @@ public class PostService {
     private final ItemService itemService;
     private final ItemImageService itemImageService;
 
+    // 게시글 생성
     @Transactional
     public List<PostDetailRes> createPostWithItemAndImages(CreatePostReq postDetail, User user) {
         // 상품, 상품 이미지 저장
@@ -56,6 +59,23 @@ public class PostService {
         }
 
         return postDetailResList;
+    }
+
+    // 게시글 목록 검색
+    @Transactional(readOnly = true)
+    public List<PostPreviewRes> getPostList(SearchPostReq condition) {
+        // 태그로 게시글 리스트 찾기
+        List<Post> posts = postRepository.searchPostsByTags(condition);
+
+        // 게시글 정보 PostPreviewRes로 정제
+        List<PostPreviewRes> postPreviewResList = new ArrayList<>();
+        for (Post post : posts) {
+            ItemImage itemImage = itemImageService.getThumbnail(post.getItem());
+            PostPreviewRes postPreviewRes = PostPreviewRes.from(post, itemImage);
+            postPreviewResList.add(postPreviewRes);
+        }
+
+        return postPreviewResList;
     }
 
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/PostService.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/PostService.java
@@ -2,6 +2,8 @@ package com.airfryer.repicka.domain.post;
 
 import com.airfryer.repicka.common.exception.CustomException;
 import com.airfryer.repicka.common.exception.CustomExceptionCode;
+import com.airfryer.repicka.domain.appointment.entity.AppointmentState;
+import com.airfryer.repicka.domain.appointment.service.AppointmentService;
 import com.airfryer.repicka.domain.item.ItemService;
 import com.airfryer.repicka.domain.item.entity.Item;
 import com.airfryer.repicka.domain.item_image.ItemImageService;
@@ -20,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final ItemService itemService;
     private final ItemImageService itemImageService;
+    private final AppointmentService appointmentService;
 
     // 게시글 생성
     @Transactional
@@ -80,13 +82,12 @@ public class PostService {
         // 태그로 게시글 리스트 찾기
         List<Post> posts = postRepository.findPostsByCondition(condition);
 
-        // TODO: 대여 날짜에 대한 필터링 appointmentService와 연결
-
         // 게시글 정보 PostPreviewRes로 정제
         List<PostPreviewRes> postPreviewResList = new ArrayList<>();
         for (Post post : posts) {
-            ItemImage itemImage = itemImageService.getThumbnail(post.getItem());
-            PostPreviewRes postPreviewRes = PostPreviewRes.from(post, itemImage);
+            boolean isAvailable = appointmentService.isPostAvailableOnDate(post.getId(), condition.getRentalDate()); // 원하는 날짜에 대여나 구매 가능 여부
+            ItemImage itemImage = itemImageService.getThumbnail(post.getItem()); // 대표 사진
+            PostPreviewRes postPreviewRes = PostPreviewRes.from(post, itemImage, isAvailable);
             postPreviewResList.add(postPreviewRes);
         }
 

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/CreatePostReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/CreatePostReq.java
@@ -15,11 +15,13 @@ public class CreatePostReq {
     private CreateItemReq item; // 상품 관련 정보 dto
 
     @NotNull(message = "게시글 타입을 입력해주세요.")
-    private PostType[] postType = new PostType[2]; // 게시글 타입 배열 (대여, 판매 복수 설정 가능)
+    private PostType[] postTypes = new PostType[2]; // 게시글 타입 배열 (대여, 판매 복수 설정 가능)
 
-    @NotNull(message = "대여료 및 판매료를 입력해주세요.")
-    @Min(value = 0, message = "대여료 또는 판매값은 0원 이상이어야 합니다.")
-    private int price; // 대여료 및 판매값
+    @Min(value = 0, message = "대여료는 0원 이상이어야 합니다.")
+    private int rentalFee; // 대여료
+
+    @Min(value = 0, message = "판매요금은 0원 이상이어야 합니다.")
+    private int salePrice; // 판매요금
 
     @Min(value = 0, message = "보증금은 0원 이상이어야 합니다.")
     private int deposit = 0; // 보증금

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/CreatePostReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/CreatePostReq.java
@@ -26,6 +26,6 @@ public class CreatePostReq {
 
     // TODO: S3 연결 이후 프론트에서 이미지를 받는 형식으로 변경
     @NotNull(message = "이미지를 첨부해주세요.")
-    @Size(min = 1, max = 10, message = "이미지는 최소 1개 이상, 최대 10개 이하이어야 합니다.")
-    private String[] images = new String[10]; // 상품 이미지
+    @Size(min = 1, max = 6, message = "이미지는 최소 1개 이상, 최대 6개 이하이어야 합니다.")
+    private String[] images = new String[6]; // 상품 이미지
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostDetailRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostDetailRes.java
@@ -2,12 +2,16 @@ package com.airfryer.repicka.domain.post.dto;
 
 import com.airfryer.repicka.domain.item.dto.BaseItemDto;
 import com.airfryer.repicka.domain.item.entity.*;
+import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import com.airfryer.repicka.domain.post.entity.Post;
 import com.airfryer.repicka.domain.post.entity.PostType;
 import com.airfryer.repicka.domain.user.dto.BaseUserDto;
 import com.airfryer.repicka.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -27,18 +31,23 @@ public class PostDetailRes {
     private int deposit = 0; // 보증급
 
     @Builder.Default
-    private String[] images = new String[10];
+    private List<String> images = new ArrayList<>();
 
     // user, item, post, imageUrl로 PostDetailRes 반환하는 정적 팩토리 메서드
-    public static PostDetailRes from(User user, Item item, Post post, String[] images) {
+    public static PostDetailRes from(Post post, List<ItemImage> itemImages) {
+        List<String> urls = new ArrayList<>();
+        for (ItemImage image : itemImages) {
+            urls.add(image.getImageUrl());
+        }
+
         return PostDetailRes.builder()
                 .id(post.getId())
-                .writer(BaseUserDto.from(user))
-                .itemInfo(BaseItemDto.from(item))
+                .writer(BaseUserDto.from(post.getWriter()))
+                .itemInfo(BaseItemDto.from(post.getItem()))
                 .postType(post.getPostType())
                 .price(post.getPrice())
                 .deposit(post.getDeposit())
-                .images(images)
+                .images(urls)
                 .build();
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostOrder.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostOrder.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum PostOrder {
     RECENT("RECENT", "최신순"),
-    LIKE("LIKE", "좋아요순");
+    LIKE("LIKE", "좋아요순"),
+    PRICE("CHEAP", "가격순");
 
     private final String code;
     private final String label;

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostOrder.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostOrder.java
@@ -1,0 +1,14 @@
+package com.airfryer.repicka.domain.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PostOrder {
+    RECENT("RECENT", "최신순"),
+    LIKE("LIKE", "좋아요순");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
@@ -3,12 +3,15 @@ package com.airfryer.repicka.domain.post.dto;
 import com.airfryer.repicka.domain.item.entity.ProductType;
 import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post.entity.PostType;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class PostPreviewRes {
+    private PostType postType; // 게시글 타입
+
     private String title; // 게시글 제목
 
     @Builder.Default
@@ -26,6 +29,7 @@ public class PostPreviewRes {
 
     public static PostPreviewRes from(Post post, ItemImage itemImage, boolean isAvailable) {
         return PostPreviewRes.builder()
+                .postType(post.getPostType())
                 .title(post.getItem().getTitle())
                 .productTypes(post.getItem().getProductTypes())
                 .thumbnail(itemImage.getImageUrl())

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
@@ -1,4 +1,35 @@
 package com.airfryer.repicka.domain.post.dto;
 
+import com.airfryer.repicka.domain.item.entity.ProductType;
+import com.airfryer.repicka.domain.item_image.entity.ItemImage;
+import com.airfryer.repicka.domain.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class PostPreviewRes {
+    private String title; // 게시글 제목
+
+    @Builder.Default
+    private ProductType[] productTypes = new ProductType[2];
+
+    private String image; // 대표 사진
+
+    private int price; // 대여료 / 판매값
+
+    private int likeCount; // 좋아요 개수
+
+    private int chatCount; // 채팅방 개수
+
+    public static PostPreviewRes from(Post post, ItemImage itemImage) {
+        return PostPreviewRes.builder()
+                .title(post.getItem().getTitle())
+                .productTypes(post.getItem().getProductTypes())
+                .image(itemImage.getImageUrl())
+                .price(post.getPrice())
+                .likeCount(post.getLikeCount())
+                .chatCount(post.getChatCount())
+                .build();
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
@@ -22,7 +22,9 @@ public class PostPreviewRes {
 
     private int chatCount; // 채팅방 개수
 
-    public static PostPreviewRes from(Post post, ItemImage itemImage) {
+    private boolean isAvailable;
+
+    public static PostPreviewRes from(Post post, ItemImage itemImage, boolean isAvailable) {
         return PostPreviewRes.builder()
                 .title(post.getItem().getTitle())
                 .productTypes(post.getItem().getProductTypes())
@@ -30,6 +32,7 @@ public class PostPreviewRes {
                 .price(post.getPrice())
                 .likeCount(post.getLikeCount())
                 .chatCount(post.getChatCount())
+                .isAvailable(isAvailable)
                 .build();
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 @Getter
 @Builder
 public class PostPreviewRes {
+    private Long id;
+
     private PostType postType; // 게시글 타입
 
     private String title; // 게시글 제목
@@ -29,6 +31,7 @@ public class PostPreviewRes {
 
     public static PostPreviewRes from(Post post, ItemImage itemImage, boolean isAvailable) {
         return PostPreviewRes.builder()
+                .id(post.getId())
                 .postType(post.getPostType())
                 .title(post.getItem().getTitle())
                 .productTypes(post.getItem().getProductTypes())

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
@@ -1,0 +1,4 @@
+package com.airfryer.repicka.domain.post.dto;
+
+public class PostPreviewRes {
+}

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostPreviewRes.java
@@ -12,9 +12,9 @@ public class PostPreviewRes {
     private String title; // 게시글 제목
 
     @Builder.Default
-    private ProductType[] productTypes = new ProductType[2];
+    private ProductType[] productTypes = new ProductType[2]; // 제품 타입
 
-    private String image; // 대표 사진
+    private String thumbnail; // 대표 사진
 
     private int price; // 대여료 / 판매값
 
@@ -26,7 +26,7 @@ public class PostPreviewRes {
         return PostPreviewRes.builder()
                 .title(post.getItem().getTitle())
                 .productTypes(post.getItem().getProductTypes())
-                .image(itemImage.getImageUrl())
+                .thumbnail(itemImage.getImageUrl())
                 .price(post.getPrice())
                 .likeCount(post.getLikeCount())
                 .chatCount(post.getChatCount())

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
@@ -3,8 +3,12 @@ package com.airfryer.repicka.domain.post.dto;
 import com.airfryer.repicka.domain.item.entity.*;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class SearchPostReq {
+    private String keyword; // 검색 키워드
+
     private ProductType productType; // 제품 타입
 
     private ItemSize size; // 제품 사이즈
@@ -14,6 +18,8 @@ public class SearchPostReq {
     private ItemQuality quality; // 제품 품질
 
     private TradeMethod tradeMethod; // 거래 방식
+
+    private LocalDateTime rentalDate; // 원하는 대여 날짜
 
     private PostOrder postOrder = PostOrder.RECENT; // 게시글 순서
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
@@ -1,0 +1,19 @@
+package com.airfryer.repicka.domain.post.dto;
+
+import com.airfryer.repicka.domain.item.entity.*;
+import lombok.Getter;
+
+@Getter
+public class SearchPostReq {
+    private ProductType productType; // 제품 타입
+
+    private ItemSize size; // 제품 사이즈
+
+    private ItemColor color; // 제품 색상
+
+    private ItemQuality quality; // 제품 품질
+
+    private TradeMethod tradeMethod; // 거래 방식
+
+    private PostOrder postOrder = PostOrder.RECENT; // 게시글 순서
+}

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
@@ -18,7 +18,7 @@ public class SearchPostReq {
 
     private ItemColor color; // 제품 색상
 
-    private LocalDateTime rentalDate; // 원하는 대여 날짜
+    private LocalDateTime date; // 원하는 거래 날짜
 
     private PostOrder postOrder = PostOrder.RECENT; // 게시글 순서
 

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
@@ -1,6 +1,7 @@
 package com.airfryer.repicka.domain.post.dto;
 
 import com.airfryer.repicka.domain.item.entity.*;
+import com.airfryer.repicka.domain.post.entity.PostType;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -20,4 +21,6 @@ public class SearchPostReq {
     private LocalDateTime rentalDate; // 원하는 대여 날짜
 
     private PostOrder postOrder = PostOrder.RECENT; // 게시글 순서
+
+    private PostType postType; // 게시글 타입
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/SearchPostReq.java
@@ -7,17 +7,15 @@ import java.time.LocalDateTime;
 
 @Getter
 public class SearchPostReq {
+    private int page = 0; // 페이지 번호 (0부터 시작)
+
     private String keyword; // 검색 키워드
 
-    private ProductType productType; // 제품 타입
+    private ProductType[] productTypes; // 제품 타입
 
     private ItemSize size; // 제품 사이즈
 
     private ItemColor color; // 제품 색상
-
-    private ItemQuality quality; // 제품 품질
-
-    private TradeMethod tradeMethod; // 거래 방식
 
     private LocalDateTime rentalDate; // 원하는 대여 날짜
 

--- a/src/main/java/com/airfryer/repicka/domain/post/entity/Post.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/entity/Post.java
@@ -52,4 +52,9 @@ public class Post extends BaseEntity
     @NotNull
     @Builder.Default
     private int likeCount = 0;
+
+    // 채팅방 개수
+    @NotNull
+    @Builder.Default
+    private int chatCount = 0;
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepository.java
@@ -6,5 +6,5 @@ import com.airfryer.repicka.domain.post.entity.Post;
 import java.util.List;
 
 public interface PostCustomRepository {
-    List<Post> searchPostsByTags(SearchPostReq condition);
+    List<Post> findPostsByCondition(SearchPostReq condition);
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepository.java
@@ -1,0 +1,4 @@
+package com.airfryer.repicka.domain.post.repository;
+
+public interface PostCustomRepository {
+}

--- a/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepository.java
@@ -1,4 +1,10 @@
 package com.airfryer.repicka.domain.post.repository;
 
+import com.airfryer.repicka.domain.post.dto.SearchPostReq;
+import com.airfryer.repicka.domain.post.entity.Post;
+
+import java.util.List;
+
 public interface PostCustomRepository {
+    List<Post> searchPostsByTags(SearchPostReq condition);
 }

--- a/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepositoryImpl.java
@@ -39,7 +39,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         }
 
         if (condition.getProductTypes() != null) {
-            builder.and(item.productTypes.in(condition.getProductTypes()));
+            // TODO: ProductType에 따라서 필터링 진행
         }
 
         if (condition.getSize() != null) {

--- a/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.airfryer.repicka.domain.post.repository;
+
+public class PostCustomRepositoryImpl {
+}

--- a/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepositoryImpl.java
@@ -27,7 +27,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
     // 태그 기반 게시글 검색
     @Override
-    public List<Post> searchPostsByTags(SearchPostReq condition) {
+    public List<Post> findPostsByCondition(SearchPostReq condition) {
         QPost post = QPost.post;
         QItem item = QItem.item;
         int offset = condition.getPage() * 10;

--- a/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,4 +1,77 @@
 package com.airfryer.repicka.domain.post.repository;
 
-public class PostCustomRepositoryImpl {
+import com.airfryer.repicka.domain.item.entity.ProductType;
+import com.airfryer.repicka.domain.item.entity.QItem;
+import com.airfryer.repicka.domain.post.dto.PostOrder;
+import com.airfryer.repicka.domain.post.dto.SearchPostReq;
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post.entity.QPost;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Repository
+public class PostCustomRepositoryImpl implements PostCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PostCustomRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    // 태그 기반 게시글 검색
+    @Override
+    public List<Post> searchPostsByTags(SearchPostReq condition) {
+        QPost post = QPost.post;
+        QItem item = QItem.item;
+        int offset = condition.getPage() * 10;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (StringUtils.hasText(condition.getKeyword())) {
+            builder.and(item.title.containsIgnoreCase(condition.getKeyword()));
+        }
+
+        if (condition.getProductTypes() != null) {
+            builder.and(item.productTypes.in(condition.getProductTypes()));
+        }
+
+        if (condition.getSize() != null) {
+            builder.and(item.size.eq(condition.getSize()));
+        }
+
+        if (condition.getColor() != null) {
+            builder.and(item.color.eq(condition.getColor()));
+        }
+
+        if (condition.getPostType() != null) {
+            builder.and(post.postType.eq(condition.getPostType()));
+        }
+
+        OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifiers(condition.getPostOrder(), post, item);
+
+        return queryFactory
+                .selectFrom(post)
+                .join(post.item, item).fetchJoin()
+                .where(builder)
+                .orderBy(orderSpecifiers)
+                .offset(offset)
+                .limit(10)
+                .fetch();
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(PostOrder postOrder, QPost post, QItem item) {
+        return switch (postOrder) {
+            case PostOrder.RECENT -> new OrderSpecifier[]{item.repostDate.desc()};
+            case PostOrder.LIKE -> new OrderSpecifier[]{post.likeCount.desc()};
+            case PostOrder.PRICE -> new OrderSpecifier[]{post.price.asc()};
+        };
+    }
 }
+

--- a/src/main/java/com/airfryer/repicka/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/repository/PostRepository.java
@@ -3,5 +3,5 @@ package com.airfryer.repicka.domain.post.repository;
 import com.airfryer.repicka.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
 }


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#13 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
### 게시물 상세 페이지 조회 기능
- controller / service layer에 getPostDetail 함수 구현하였습니다.

### 태그 기반 게시물 검색 기능
- 검색 시 사용 가능한 옵션은 다음과 같습니다.
  - keyword 검색 키워드
  - productTypes 제품 타입
  - size 제품 사이즈
  - color 제품 색상
  - date 원하는 날짜
  - postOrder 게시글 순서(가격순, 최신순, 좋아요순)
  - postType 게시글 타입
- 태그 기반 게시물 검색을 위해 QueryDSL을 이용한 동적 쿼리 작성하였습니다.
  - 요청 시 조건DTO를 한번에 넘겨 받은 후 존재 여부에 따라 동적 쿼리를 생성하는 PostCustomRepositoy를 따로 구현하였습니다.
- 게시물 검색에 대하여 각 page마다 10개의 게시물을 전달합니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- productTypes 조건 기반 검색 시 queryDSL 구현 마저 진행

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>