### PR TITLE
[FEAT#25]: S3 연결 및 이미지 업로드 구현

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -56,6 +56,7 @@ jobs:
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .env
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
           echo "AWS_BUCKET_NAME=${{ secrets.AWS_BUCKET_NAME }}" >> .env
+          echo "AWS_CLOUDFRONT_DOMAIN=${{ secrets.AWS_CLOUDFRONT_DOMAIN }}" >> .env
 
       - name: Pull latest Docker image
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,6 +52,10 @@ jobs:
           echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
           echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
           echo "FRONTEND_URI=${{ secrets.FRONTEND_URI }}" >> .env
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> .env
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .env
+          echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
+          echo "AWS_BUCKET_NAME=${{ secrets.AWS_BUCKET_NAME }}" >> .env
 
       - name: Pull latest Docker image
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/airfryer/repicka/common/aws/s3/S3Controller.java
+++ b/src/main/java/com/airfryer/repicka/common/aws/s3/S3Controller.java
@@ -18,11 +18,12 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
+    // 테스트용 이미지 업로드 api
     @PostMapping("/image")
     public ResponseEntity<SuccessResponseDto> uploadFile(
             @RequestParam(value = "image", required = false) MultipartFile image)
     {
-        String imageUrl = s3Service.uploadImage(image);
+        String imageUrl = s3Service.uploadImage(image, "image");
         return ResponseEntity.ok(SuccessResponseDto.builder()
                 .message("이미지 업로드 성공")
                 .data(imageUrl)
@@ -33,7 +34,7 @@ public class S3Controller {
     public ResponseEntity<SuccessResponseDto> uploadImages(
             @RequestParam(value = "images", required = false) MultipartFile[] images)  
     {
-        String[] imageUrls = s3Service.uploadImages(images);
+        String[] imageUrls = s3Service.uploadImages(images, "images");
         return ResponseEntity.ok(SuccessResponseDto.builder()
                 .message("이미지 업로드 성공")
                 .data(imageUrls)

--- a/src/main/java/com/airfryer/repicka/common/aws/s3/S3Controller.java
+++ b/src/main/java/com/airfryer/repicka/common/aws/s3/S3Controller.java
@@ -1,7 +1,5 @@
 package com.airfryer.repicka.common.aws.s3;
 
-import java.util.Arrays;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,8 +7,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.airfryer.repicka.common.exception.CustomException;
-import com.airfryer.repicka.common.exception.CustomExceptionCode;
 import com.airfryer.repicka.common.response.SuccessResponseDto;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/airfryer/repicka/common/aws/s3/S3Controller.java
+++ b/src/main/java/com/airfryer/repicka/common/aws/s3/S3Controller.java
@@ -1,0 +1,34 @@
+package com.airfryer.repicka.common.aws.s3;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.airfryer.repicka.common.response.SuccessResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/s3")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/image")
+    public ResponseEntity<SuccessResponseDto> uploadFile(@RequestParam("image") MultipartFile image)
+    {
+        String imageUrl = s3Service.uploadImage(image);
+        return ResponseEntity.ok(SuccessResponseDto.builder().message("이미지 업로드 성공").data(imageUrl).build());
+    }
+
+    @PostMapping("/images")
+    public ResponseEntity<SuccessResponseDto> uploadImages(@RequestParam("images") MultipartFile[] images)  
+    {
+        String[] imageUrls = s3Service.uploadImages(images);
+        return ResponseEntity.ok(SuccessResponseDto.builder().message("이미지 업로드 성공").data(imageUrls).build());
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/aws/s3/S3Controller.java
+++ b/src/main/java/com/airfryer/repicka/common/aws/s3/S3Controller.java
@@ -1,5 +1,7 @@
 package com.airfryer.repicka.common.aws.s3;
 
+import java.util.Arrays;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.airfryer.repicka.common.exception.CustomException;
+import com.airfryer.repicka.common.exception.CustomExceptionCode;
 import com.airfryer.repicka.common.response.SuccessResponseDto;
 
 import lombok.RequiredArgsConstructor;
@@ -19,16 +23,25 @@ public class S3Controller {
     private final S3Service s3Service;
 
     @PostMapping("/image")
-    public ResponseEntity<SuccessResponseDto> uploadFile(@RequestParam("image") MultipartFile image)
+    public ResponseEntity<SuccessResponseDto> uploadFile(
+            @RequestParam(value = "image", required = false) MultipartFile image)
     {
         String imageUrl = s3Service.uploadImage(image);
-        return ResponseEntity.ok(SuccessResponseDto.builder().message("이미지 업로드 성공").data(imageUrl).build());
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+                .message("이미지 업로드 성공")
+                .data(imageUrl)
+                .build());
     }
 
     @PostMapping("/images")
-    public ResponseEntity<SuccessResponseDto> uploadImages(@RequestParam("images") MultipartFile[] images)  
+    public ResponseEntity<SuccessResponseDto> uploadImages(
+            @RequestParam(value = "images", required = false) MultipartFile[] images)  
     {
         String[] imageUrls = s3Service.uploadImages(images);
-        return ResponseEntity.ok(SuccessResponseDto.builder().message("이미지 업로드 성공").data(imageUrls).build());
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+                .message("이미지 업로드 성공")
+                .data(imageUrls)
+                .build());
     }
+
 }

--- a/src/main/java/com/airfryer/repicka/common/aws/s3/S3Service.java
+++ b/src/main/java/com/airfryer/repicka/common/aws/s3/S3Service.java
@@ -55,6 +55,10 @@ public class S3Service {
     
     // 다중 이미지 업로드
     public String[] uploadImages(MultipartFile[] files) {
+        if (files == null || files.length == 0) {
+            throw new CustomException(CustomExceptionCode.INVALID_FILE_FORMAT, "업로드할 파일이 없습니다");
+        }
+        
         return Arrays.stream(files)
             .map(this::uploadImage)
             .toArray(String[]::new);
@@ -63,21 +67,21 @@ public class S3Service {
     // 파일 유효성 검사
     private void validateFile(MultipartFile file) {
         // 파일이 비어있는지 확인
-        if (file.isEmpty()) {
-            throw new CustomException(CustomExceptionCode.FILE_NOT_FOUND, "업로드할 파일이 없습니다");
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(CustomExceptionCode.INVALID_FILE_FORMAT, "업로드할 파일이 없습니다");
         }
         
         // 파일 크기 확인
         if (file.getSize() > MAX_FILE_SIZE) {
             throw new CustomException(CustomExceptionCode.FILE_SIZE_EXCEEDED, 
-                String.format("파일 크기가 너무 큽니다. 파일 크기: %d bytes, 최대 허용: %d bytes", file.getSize(), MAX_FILE_SIZE));
+                String.format("파일 크기: %d bytes, 최대 허용: %d bytes", file.getSize(), MAX_FILE_SIZE));
         }
         
         // 파일 확장자 확인
         String originalFilename = file.getOriginalFilename();
         if (originalFilename == null || !isValidImageExtension(originalFilename)) {
             throw new CustomException(CustomExceptionCode.INVALID_FILE_FORMAT, 
-                "이미지 형식이 허용되지 않습니다. 허용되는 이미지 형식: " + String.join(", ", ALLOWED_EXTENSIONS));
+                "허용되는 이미지 형식: " + String.join(", ", ALLOWED_EXTENSIONS));
         }
     }
     

--- a/src/main/java/com/airfryer/repicka/common/aws/s3/S3Service.java
+++ b/src/main/java/com/airfryer/repicka/common/aws/s3/S3Service.java
@@ -1,0 +1,89 @@
+package com.airfryer.repicka.common.aws.s3;
+
+import com.airfryer.repicka.common.exception.CustomException;
+import com.airfryer.repicka.common.exception.CustomExceptionCode;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    
+    private final AmazonS3 amazonS3;
+    
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+    
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif", "webp");
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+    
+    // 단일 이미지 업로드
+    public String uploadImage(MultipartFile file) {
+        try {
+            validateFile(file);
+            
+            String fileName = "images/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(file.getContentType());
+            metadata.setContentLength(file.getSize());
+            
+            // S3에 파일 업로드
+            PutObjectRequest putObjectRequest = new PutObjectRequest(
+                bucket, 
+                fileName, 
+                file.getInputStream(), 
+                metadata
+            );
+            amazonS3.putObject(putObjectRequest);
+            return amazonS3.getUrl(bucket, fileName).toString();
+            
+        } catch (IOException e) {
+            throw new CustomException(CustomExceptionCode.FILE_UPLOAD_FAILED, file.getOriginalFilename());
+            
+        }
+    }
+    
+    // 다중 이미지 업로드
+    public String[] uploadImages(MultipartFile[] files) {
+        return Arrays.stream(files)
+            .map(this::uploadImage)
+            .toArray(String[]::new);
+    }
+    
+    // 파일 유효성 검사
+    private void validateFile(MultipartFile file) {
+        // 파일이 비어있는지 확인
+        if (file.isEmpty()) {
+            throw new CustomException(CustomExceptionCode.FILE_NOT_FOUND, "업로드할 파일이 없습니다");
+        }
+        
+        // 파일 크기 확인
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new CustomException(CustomExceptionCode.FILE_SIZE_EXCEEDED, 
+                String.format("파일 크기가 너무 큽니다. 파일 크기: %d bytes, 최대 허용: %d bytes", file.getSize(), MAX_FILE_SIZE));
+        }
+        
+        // 파일 확장자 확인
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !isValidImageExtension(originalFilename)) {
+            throw new CustomException(CustomExceptionCode.INVALID_FILE_FORMAT, 
+                "이미지 형식이 허용되지 않습니다. 허용되는 이미지 형식: " + String.join(", ", ALLOWED_EXTENSIONS));
+        }
+    }
+    
+    // 이미지 파일 확장자 검사
+    private boolean isValidImageExtension(String filename) {
+        String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+        return ALLOWED_EXTENSIONS.contains(extension);
+    }
+} 

--- a/src/main/java/com/airfryer/repicka/common/aws/s3/S3Service.java
+++ b/src/main/java/com/airfryer/repicka/common/aws/s3/S3Service.java
@@ -32,7 +32,7 @@ public class S3Service {
         try {
             validateFile(file);
             
-            String fileName = "images/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+            String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentType(file.getContentType());
             metadata.setContentLength(file.getSize());
@@ -56,7 +56,7 @@ public class S3Service {
     // 다중 이미지 업로드
     public String[] uploadImages(MultipartFile[] files) {
         if (files == null || files.length == 0) {
-            throw new CustomException(CustomExceptionCode.INVALID_FILE_FORMAT, "업로드할 파일이 없습니다");
+            throw new CustomException(CustomExceptionCode.FILE_NOT_FOUND, "업로드할 파일이 없습니다");
         }
         
         return Arrays.stream(files)
@@ -68,7 +68,7 @@ public class S3Service {
     private void validateFile(MultipartFile file) {
         // 파일이 비어있는지 확인
         if (file == null || file.isEmpty()) {
-            throw new CustomException(CustomExceptionCode.INVALID_FILE_FORMAT, "업로드할 파일이 없습니다");
+            throw new CustomException(CustomExceptionCode.FILE_NOT_FOUND, "업로드할 파일이 없습니다");
         }
         
         // 파일 크기 확인

--- a/src/main/java/com/airfryer/repicka/common/configuration/S3Config.java
+++ b/src/main/java/com/airfryer/repicka/common/configuration/S3Config.java
@@ -1,0 +1,37 @@
+package com.airfryer.repicka.common.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+
+// S3 설정 클래스
+@Configuration
+public class S3Config {
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+    
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(
+                    new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -35,6 +35,12 @@ public enum CustomExceptionCode
     ALREADY_CONFIRMED_APPOINTMENT(HttpStatus.CONFLICT, "이미 확정된 약속입니다."),
     APPOINTMENT_CANNOT_CANCELLED(HttpStatus.CONFLICT, "취소할 수 없는 상태입니다."),
 
+    // 파일 관련 예외
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
+    INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+
     // 내부 로직 오류 (발생하면 안됨!)
     SALE_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "제품은 판매 예정인데, 판매 게시글 데이터를 찾을 수 없습니다. (내부 로직 오류)"),
     SALE_APPOINTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "제품은 판매 예정인데, 판매 약속 데이터를 찾을 수 없습니다. (내부 로직 오류)");

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -39,7 +39,7 @@ public enum CustomExceptionCode
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
-    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+    FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "파일을 찾을 수 없습니다."),
 
     // 내부 로직 오류 (발생하면 안됨!)
     SALE_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "제품은 판매 예정인데, 판매 게시글 데이터를 찾을 수 없습니다. (내부 로직 오류)"),

--- a/src/main/java/com/airfryer/repicka/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/GlobalExceptionHandler.java
@@ -1,20 +1,16 @@
 package com.airfryer.repicka.common.exception;
 
 import com.airfryer.repicka.common.response.ExceptionResponseDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.FieldError;
-import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-import java.time.format.DateTimeParseException;
-import java.util.HashMap;
-import java.util.Map;
-
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler
 {
@@ -22,6 +18,8 @@ public class GlobalExceptionHandler
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ExceptionResponseDto> customExceptionHandler(CustomException e)
     {
+        log.error("CustomException occurred: ", e);
+
         return ResponseEntity.status(e.getCode().getHttpStatus())
                 .body(ExceptionResponseDto.builder()
                         .code(e.getCode().name())
@@ -34,6 +32,8 @@ public class GlobalExceptionHandler
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponseDto> handleMethodArgumentNotValidException(MethodArgumentNotValidException e)
     {
+        log.error("MethodArgumentNotValidException occurred: ", e);
+
         String message = e.getBindingResult().getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .findFirst()
@@ -51,6 +51,8 @@ public class GlobalExceptionHandler
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ExceptionResponseDto> handleHttpMessageNotReadableException(HttpMessageNotReadableException e)
     {
+        log.error("HttpMessageNotReadableException occurred: ", e);
+
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ExceptionResponseDto.builder()
                         .code("INVALID_INPUT")
@@ -63,10 +65,85 @@ public class GlobalExceptionHandler
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ExceptionResponseDto> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e)
     {
+        log.error("MethodArgumentTypeMismatchException occurred: ", e);
+        
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ExceptionResponseDto.builder()
                         .code("INVALID_INPUT")
                         .message(e.getMessage())
+                        .data(null)
+                        .build());
+    }
+
+    // NullPointerException 처리 핸들러
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<ExceptionResponseDto> handleNullPointerException(NullPointerException e)
+    {
+        log.error("NullPointerException occurred: ", e);
+        
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ExceptionResponseDto.builder()
+                        .code("NULL_POINTER_ERROR")
+                        .message("필수 데이터가 누락되었습니다.")
+                        .data(null)
+                        .build());
+    }
+
+    // IllegalArgumentException 처리 핸들러
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ExceptionResponseDto> handleIllegalArgumentException(IllegalArgumentException e)
+    {
+        log.error("IllegalArgumentException occurred: ", e);
+        
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ExceptionResponseDto.builder()
+                        .code("ILLEGAL_ARGUMENT_ERROR")
+                        .message("잘못된 매개변수가 전달되었습니다.")
+                        .data(null)
+                        .build());
+    }
+
+    // 데이터베이스 관련 예외 처리 핸들러
+    @ExceptionHandler({
+        org.springframework.dao.DataAccessException.class,
+        jakarta.persistence.PersistenceException.class
+    })
+    public ResponseEntity<ExceptionResponseDto> handleDatabaseException(Exception e)
+    {
+        log.error("Database Exception occurred: ", e);
+        
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ExceptionResponseDto.builder()
+                        .code("DATABASE_ERROR")
+                        .message("데이터베이스 처리 중 오류가 발생했습니다.")
+                        .data(null)
+                        .build());
+    }
+
+    // 런타임 예외 처리 핸들러 (NullPointerException, IllegalArgumentException 등)
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ExceptionResponseDto> handleRuntimeException(RuntimeException e)
+    {
+        log.error("Runtime Exception occurred: ", e);
+        
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ExceptionResponseDto.builder()
+                        .code("INTERNAL_SERVER_ERROR")
+                        .message("서버 내부 오류가 발생했습니다.")
+                        .data(null)
+                        .build());
+    }
+
+    // 모든 예상치 못한 예외 처리 핸들러 (최종 안전망)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponseDto> handleException(Exception e)
+    {
+        log.error("Unexpected Exception occurred: ", e);
+        
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ExceptionResponseDto.builder()
+                        .code("INTERNAL_SERVER_ERROR")
+                        .message("예상치 못한 서버 오류가 발생했습니다.")
                         .data(null)
                         .build());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,17 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+  ## S3 Cloud 설정
+  cloud:
+    aws:
+      s3:
+        bucket: ${AWS_S3_BUCKET_NAME}
+      region:
+        static: ${AWS_REGION}
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+
 ## Spring Security 로그 설정
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,8 @@ spring:
       credentials:
         access-key: ${AWS_ACCESS_KEY_ID}
         secret-key: ${AWS_SECRET_ACCESS_KEY}
+      cloudfront:
+        domain: ${AWS_CLOUDFRONT_DOMAIN}
 
 ## Spring Security 로그 설정
 logging:


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#25 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
- S3Config: 기본적인 AWS S3 연결 설정을 담당합니다.
- S3Service: MultipartFile 형식의 이미지를 S3 Bucket에 저장하고 Cloudfront에서 제공하는 url을 반환합니다.
   - 단일 업로드와 다중 업로드로 나뉘어있습니다.
   - 파일 크기 및 이미지 형식(확장자)을 검증합니다.
- S3Controller: 이미지 업로드 시 url을 반환하는 API를 구현하였습니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- 

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
- 프론트 측에서 이미지를 저장과 함께 수행해야 하는 요청이 있을 경우, form-data에 image와 함께 request body를 전달하는 방식 / API를 분리하여 이미지에 대한 링크를 받고 다시 json body에 해당 링크를 포함하여 요청하는 방식 중 어떤 것이 좋을지에 따라 S3Controller의 존재 여부가 결정될 것 같습니다... 

<br>