### PR TITLE
[FEAT#27]: Access token 재발급 API 구현

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -12,6 +12,13 @@ public enum CustomExceptionCode
     NOT_LOGIN(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
     LOW_AUTHORITY(HttpStatus.UNAUTHORIZED, "권한이 부족합니다."),
 
+    // 토큰 관련 예외
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh token이 존재하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh token입니다."),
+
+    // 사용자 관련 예외
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 데이터를 찾을 수 없습니다."),
+
     // 제품(Item) 관련 예외
     DEAL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "가격 협의가 불가능한 제품입니다."),
     ALREADY_SALE_RESERVED(HttpStatus.CONFLICT, "이미 판매가 예정된 제품입니다."),

--- a/src/main/java/com/airfryer/repicka/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -66,6 +67,18 @@ public class GlobalExceptionHandler
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ExceptionResponseDto.builder()
                         .code("INVALID_INPUT")
+                        .message(e.getMessage())
+                        .data(null)
+                        .build());
+    }
+
+    // @CookieValue 쿠키 누락 예외 처리 핸들러
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ExceptionResponseDto> handleMissingRequestCookieException(MissingRequestCookieException e)
+    {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ExceptionResponseDto.builder()
+                        .code("쿠키가 누락되었습니다.")
                         .message(e.getMessage())
                         .data(null)
                         .build());

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/controller/TokenController.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/controller/TokenController.java
@@ -1,0 +1,40 @@
+package com.airfryer.repicka.common.security.jwt.controller;
+
+import com.airfryer.repicka.common.response.SuccessResponseDto;
+import com.airfryer.repicka.common.security.jwt.service.TokenService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class TokenController
+{
+    private final TokenService tokenService;
+
+    // Access token 재발급
+    @PostMapping("/refresh-token")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<SuccessResponseDto> refreshToken(@CookieValue(name = "refreshToken", required = false) String refreshToken,
+                                                           HttpServletResponse response)
+    {
+        ResponseCookie cookie = tokenService.refreshToken(refreshToken);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("Access token을 성공적으로 재발급하였습니다.")
+                        .data(null)
+                        .build());
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/controller/TokenController.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/controller/TokenController.java
@@ -25,10 +25,10 @@ public class TokenController
     // Access token 재발급
     @PostMapping("/refresh-token")
     @PreAuthorize("permitAll()")
-    public ResponseEntity<SuccessResponseDto> refreshToken(@CookieValue(name = "refreshToken", required = false) String refreshToken,
-                                                           HttpServletResponse response)
+    public ResponseEntity<SuccessResponseDto> reissueAccessToken(@CookieValue(name = "refreshToken", required = false) String refreshToken,
+                                                                 HttpServletResponse response)
     {
-        ResponseCookie cookie = tokenService.refreshToken(refreshToken);
+        ResponseCookie cookie = tokenService.reissueAccessToken(refreshToken);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/controller/TokenController.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/controller/TokenController.java
@@ -25,7 +25,7 @@ public class TokenController
     // Access token 재발급
     @PostMapping("/refresh-token")
     @PreAuthorize("permitAll()")
-    public ResponseEntity<SuccessResponseDto> reissueAccessToken(@CookieValue(name = "refreshToken", required = false) String refreshToken,
+    public ResponseEntity<SuccessResponseDto> reissueAccessToken(@CookieValue(name = "refreshToken") String refreshToken,
                                                                  HttpServletResponse response)
     {
         ResponseCookie cookie = tokenService.reissueAccessToken(refreshToken);

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/service/TokenService.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/service/TokenService.java
@@ -20,7 +20,7 @@ public class TokenService
 
     // Access token 재발급
     @Transactional(readOnly = true)
-    public ResponseCookie refreshToken(String refreshToken)
+    public ResponseCookie reissueAccessToken(String refreshToken)
     {
         /// Refresh token 유효성 체크
         /// 1. Refresh token이 존재하는가?

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/service/TokenService.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/service/TokenService.java
@@ -1,0 +1,55 @@
+package com.airfryer.repicka.common.security.jwt.service;
+
+import com.airfryer.repicka.common.exception.CustomException;
+import com.airfryer.repicka.common.exception.CustomExceptionCode;
+import com.airfryer.repicka.common.security.jwt.JwtUtil;
+import com.airfryer.repicka.common.security.jwt.Token;
+import com.airfryer.repicka.domain.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService
+{
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    // Access token 재발급
+    @Transactional(readOnly = true)
+    public ResponseCookie refreshToken(String refreshToken)
+    {
+        /// Refresh token 유효성 체크
+        /// 1. Refresh token이 존재하는가?
+        /// 2. Refresh token이 유효한가?
+
+        // Refresh token 존재 여부 체크
+        if(refreshToken == null) {
+            throw new CustomException(CustomExceptionCode.REFRESH_TOKEN_NOT_FOUND, null);
+        }
+
+        // 토큰이 유효한지 체크
+        if(!jwtUtil.checkToken(refreshToken)) {
+            throw new CustomException(CustomExceptionCode.INVALID_REFRESH_TOKEN, refreshToken);
+        }
+
+        /// 계정 존재 확인
+
+        // 사용자 ID 추출
+        Long userId = jwtUtil.getUserIdFromToken(refreshToken);
+
+        // 계정 존재 확인
+        userRepository.findById(userId).orElseThrow(() -> new CustomException(CustomExceptionCode.USER_NOT_FOUND, userId));
+
+        /// Access token 재발급
+
+        // Access token 발급
+        String accessToken = jwtUtil.createToken(userId, Token.ACCESS_TOKEN);
+
+        // 토큰을 쿠키로 변환 후, 반환
+        return jwtUtil.parseTokenToCookie(accessToken, Token.ACCESS_TOKEN);
+    }
+}


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#27 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
**생성한 파일**
- **TokenController** : JWT 토큰과 관련된 API 엔드포인트를 관리합니다.
- **TokenService** : JWT 토큰과 관련된 API 처리 비즈니스 로직을 관리합니다.

<br/>

**구현 API**
- **Access token 재발급 ( /api/v1/refresh-token )**
- "refreshToken" 쿠키를 가진 사용자가 요청을 보내면, Access token을 발급하여 쿠키로 반환합니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
-

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>