### PR TITLE
[FEAT#14]: 나의 PICK 조회 API 구현

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -32,7 +32,7 @@ public enum CustomExceptionCode
     CREATOR_CANNOT_AGREE(HttpStatus.BAD_REQUEST, "본인이 제시한 약속을 본인이 확정할 수는 없습니다."),
     ALREADY_RENTAL_RESERVED_PERIOD(HttpStatus.CONFLICT, "해당 구간 동안 이미 대여 약속이 예정되어 있습니다."),
     ALREADY_SALE_RESERVED_PERIOD(HttpStatus.CONFLICT, "해당 구간 동안 이미 판매 약속이 예정되어 있습니다."),
-    ALREADY_CONFIRMED_APPOINTMENT(HttpStatus.CONFLICT, "이미 확정된 약속입니다."),
+    NOT_PENDING_APPOINTMENT(HttpStatus.CONFLICT, "제시 중인 약속이 아닙니다."),
     APPOINTMENT_CANNOT_CANCELLED(HttpStatus.CONFLICT, "취소할 수 없는 상태입니다."),
 
     // 내부 로직 오류 (발생하면 안됨!)

--- a/src/main/java/com/airfryer/repicka/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -66,6 +67,18 @@ public class GlobalExceptionHandler
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ExceptionResponseDto.builder()
                         .code("INVALID_INPUT")
+                        .message(e.getMessage())
+                        .data(null)
+                        .build());
+    }
+
+    // @RequestParm 누락 예외 처리 핸들러
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ExceptionResponseDto> handleMissingServletRequestParameterException(MissingServletRequestParameterException e)
+    {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ExceptionResponseDto.builder()
+                        .code("RequestParam이 누락되었습니다.")
                         .message(e.getMessage())
                         .data(null)
                         .build());

--- a/src/main/java/com/airfryer/repicka/domain/appointment/FindMyPickPeriod.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/FindMyPickPeriod.java
@@ -1,0 +1,26 @@
+package com.airfryer.repicka.domain.appointment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+
+@Getter
+@AllArgsConstructor
+public enum FindMyPickPeriod
+{
+    YEAR("YEAR", "1년", Period.ofYears(1)),
+    SIX_MONTH("SIX_MONTH", "6개월", Period.ofMonths(6)),
+    WEEK("WEEK", "일주일", Period.ofWeeks(1));
+
+    private final String code;
+    private final String label;
+    private final Period period;
+
+    // 특정 기준 날짜로부터 기간을 뺀 날짜를 반환
+    public LocalDateTime calculateFromDate(LocalDateTime baseDate) {
+        return baseDate.minus(period);
+    }
+}

--- a/src/main/java/com/airfryer/repicka/domain/appointment/controller/AppointmentController.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/controller/AppointmentController.java
@@ -2,11 +2,14 @@ package com.airfryer.repicka.domain.appointment.controller;
 
 import com.airfryer.repicka.common.response.SuccessResponseDto;
 import com.airfryer.repicka.common.security.oauth2.CustomOAuth2User;
+import com.airfryer.repicka.domain.appointment.FindMyPickPeriod;
 import com.airfryer.repicka.domain.appointment.dto.*;
 import com.airfryer.repicka.domain.appointment.service.AppointmentService;
+import com.airfryer.repicka.domain.post.entity.PostType;
 import com.airfryer.repicka.domain.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -116,6 +119,25 @@ public class AppointmentController
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponseDto.builder()
                         .message("약속을 성공적으로 취소하였습니다.")
+                        .data(data)
+                        .build());
+    }
+
+    // 나의 PICK 페이지 조회
+    // 요청자가 requester인 (확정/대여중/완료) 상태의 약속 페이지 조회
+    @GetMapping("/appointment/my-pick")
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
+    public ResponseEntity<SuccessResponseDto> findMyPick(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+                                                         Pageable pageable,
+                                                         @RequestParam PostType type,
+                                                         @RequestParam FindMyPickPeriod period)
+    {
+        User requester = oAuth2User.getUser();
+        AppointmentPageRes data = appointmentService.findMyPick(requester, pageable, type, period);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("나의 PICK 페이지를 성공적으로 조회하였습니다.")
                         .data(data)
                         .build());
     }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/dto/AppointmentPageRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/dto/AppointmentPageRes.java
@@ -1,0 +1,91 @@
+package com.airfryer.repicka.domain.appointment.dto;
+
+import com.airfryer.repicka.domain.appointment.entity.Appointment;
+import com.airfryer.repicka.domain.appointment.entity.AppointmentState;
+import com.airfryer.repicka.domain.item.entity.Item;
+import com.airfryer.repicka.domain.item.entity.ProductType;
+import com.airfryer.repicka.domain.item_image.entity.ItemImage;
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post.entity.PostType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class AppointmentPageRes
+{
+    private List<AppointmentInfo> appointmentInfoList;   // 약속 정보 리스트
+
+    private PostType type;      // 타입 (대여/구매)
+    private int currentPage;    // 현재 페이지 번호
+    private int totalPages;     // 전체 페이지 개수
+
+    public static AppointmentPageRes of(Map<Appointment, Optional<ItemImage>> map,
+                                        PostType postType,
+                                        int currentPage,
+                                        int totalPages)
+    {
+        return AppointmentPageRes.builder()
+                .appointmentInfoList(map.entrySet().stream().map(entry -> {
+                    return AppointmentInfo.from(entry.getKey(), entry.getValue());
+                }).toList())
+                .type(postType)
+                .currentPage(currentPage)
+                .totalPages(totalPages)
+                .build();
+    }
+
+    @Getter
+    @Builder(access = AccessLevel.PRIVATE)
+    private static class AppointmentInfo
+    {
+        private Long appointmentId;     // 약속 ID
+        private Long postId;            // 게시글 ID
+        private Long itemId;            // 제품 ID
+        private Long requesterId;       // 대여자(구매자) ID
+        private Long ownerId;           // 소유자 ID
+
+        private String imageUrl;            // 이미지 URL
+        private String title;               // 게시글 제목
+        private String description;         // 게시글 설명
+        private ProductType[] productTypes; // 제품 타입
+        private LocalDateTime rentalDate;   // 대여(구매) 일시
+        private LocalDateTime returnDate;   // 반납 일시
+        private String rentalLocation;      // 대여(구매) 장소
+        private String returnLocation;      // 반납 장소
+        private int price;                  // 대여료(판매값)
+        private int deposit;                // 보증금
+        private AppointmentState state;     // 약속 상태
+
+        private static AppointmentInfo from(Appointment appointment, Optional<ItemImage> itemImage)
+        {
+            Post post = appointment.getPost();
+            Item item = post.getItem();
+
+            return AppointmentInfo.builder()
+                    .appointmentId(appointment.getId())
+                    .postId(post.getId())
+                    .itemId(item.getId())
+                    .requesterId(appointment.getRequester().getId())
+                    .ownerId(appointment.getOwner().getId())
+                    .imageUrl(itemImage.map(ItemImage::getImageUrl).orElse(null))
+                    .title(item.getTitle())
+                    .description(item.getDescription())
+                    .productTypes(item.getProductTypes())
+                    .rentalDate(appointment.getRentalDate())
+                    .returnDate(appointment.getReturnDate())
+                    .rentalLocation(appointment.getRentalLocation())
+                    .returnLocation(appointment.getReturnLocation())
+                    .price(appointment.getPrice())
+                    .deposit(appointment.getDeposit())
+                    .state(appointment.getState())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/airfryer/repicka/domain/appointment/dto/AppointmentRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/dto/AppointmentRes.java
@@ -1,13 +1,16 @@
 package com.airfryer.repicka.domain.appointment.dto;
 
+import com.airfryer.repicka.domain.appointment.entity.Appointment;
+import com.airfryer.repicka.domain.post.entity.Post;
 import com.airfryer.repicka.domain.post.entity.PostType;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public class AppointmentRes
 {
     private Long appointmentId;     // 약속 ID
@@ -22,4 +25,21 @@ public class AppointmentRes
     private String returnLocation;      // 반납 장소
     private int price;                  // 대여료(판매값)
     private int deposit;                // 보증금
+
+    public static AppointmentRes from(Appointment appointment, Post post)
+    {
+        return AppointmentRes.builder()
+                .appointmentId(appointment.getId())
+                .postId(post.getId())
+                .ownerId(appointment.getOwner().getId())
+                .borrowerId(appointment.getRequester().getId())
+                .type(post.getPostType())
+                .rentalDate(appointment.getRentalDate())
+                .returnDate(appointment.getReturnDate())
+                .rentalLocation(appointment.getRentalLocation())
+                .returnLocation(appointment.getReturnLocation())
+                .price(appointment.getPrice())
+                .deposit(appointment.getDeposit())
+                .build();
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/entity/Appointment.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/entity/Appointment.java
@@ -47,7 +47,7 @@ public class Appointment extends BaseEntity
     // 대여자(구매자)
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "borrower")
+    @JoinColumn(name = "requester")
     private User requester;
 
     // 대여(구매) 일시

--- a/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
@@ -3,7 +3,10 @@ package com.airfryer.repicka.domain.appointment.repository;
 import com.airfryer.repicka.domain.appointment.entity.Appointment;
 import com.airfryer.repicka.domain.appointment.entity.AppointmentState;
 import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post.entity.PostType;
 import com.airfryer.repicka.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -41,4 +44,36 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long>
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    // 대여자(구매자) ID, 검색 시작 날짜, 게시글 타입으로 (확정/대여중/완료) 상태인 약속 페이지 조회
+    @Query("""
+        SELECT a FROM Appointment a
+        WHERE a.requester.id = :requesterId AND
+            a.post.postType = :type AND
+            a.rentalDate >= :start AND (
+                (a.state = 'CONFIRMED') OR
+                (a.state = 'IN_PROGRESS') OR
+                (a.state = 'SUCCESS')
+            )
+    """)
+    Page<Appointment> findMyPickPageByRequesterId(Pageable pageable,
+                                                  @Param("requesterId") Long requesterId,
+                                                  @Param("type") PostType type,
+                                                  @Param("start") LocalDateTime start);
+
+    // 소유자 ID, 검색 시작 날짜, 게시글 타입으로 (확정/대여중/완료) 상태인 약속 페이지 조회
+    @Query("""
+        SELECT a FROM Appointment a
+        WHERE a.owner.id = :ownerId AND
+            a.post.postType = :type AND
+            a.rentalDate >= :start AND (
+                (a.state = 'CONFIRMED') OR
+                (a.state = 'IN_PROGRESS') OR
+                (a.state = 'SUCCESS')
+            )
+    """)
+    Page<Appointment> findMyPickPageByOwnerId(Pageable pageable,
+                                              @Param("ownerId") Long ownerId,
+                                              @Param("type") PostType type,
+                                              @Param("start") LocalDateTime start);
 }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -426,13 +426,13 @@ public class AppointmentService
                 .orElseThrow(() -> new CustomException(CustomExceptionCode.APPOINTMENT_NOT_FOUND, appointmentId));
 
         /// 예외 처리
-        /// 1. 약속이 이미 확정되었는가?
+        /// 1. 약속이 제시 중인가?
         /// 2. 동의자와 약속 생성자가 다른 사용자인가?
         /// 3. 동의자가 약속 관계자인가?
 
         // 이미 확정된 약속인 경우, 예외 처리
-        if(appointment.getState() == AppointmentState.CONFIRMED) {
-            throw new CustomException(CustomExceptionCode.ALREADY_CONFIRMED_APPOINTMENT, null);
+        if(appointment.getState() != AppointmentState.PENDING) {
+            throw new CustomException(CustomExceptionCode.NOT_PENDING_APPOINTMENT, null);
         }
 
         // 동의자와 약속 생성자가 동일한 경우, 예외 처리

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -504,26 +504,14 @@ public class AppointmentService
             itemRepository.save(item);
         }
 
-        /// 약속 확정 및 약속 데이터 반환
+        /// 약속 확정
 
-        // 약속 확정
         appointment.confirmAppointment();
         appointmentRepository.save(appointment);
 
-        // 약속 데이터 반환
-        return AppointmentRes.builder()
-                .appointmentId(appointment.getId())
-                .postId(post.getId())
-                .ownerId(appointment.getOwner().getId())
-                .borrowerId(appointment.getRequester().getId())
-                .type(post.getPostType())
-                .rentalDate(appointment.getRentalDate())
-                .returnDate(appointment.getReturnDate())
-                .rentalLocation(appointment.getRentalLocation())
-                .returnLocation(appointment.getReturnLocation())
-                .price(appointment.getPrice())
-                .deposit(appointment.getDeposit())
-                .build();
+        /// 약속 데이터 반환
+
+        return AppointmentRes.from(appointment, post);
     }
 
     // 약속 취소
@@ -581,20 +569,7 @@ public class AppointmentService
 
         /// 약속 데이터 반환
 
-        // 약속 데이터 반환
-        return AppointmentRes.builder()
-                .appointmentId(appointment.getId())
-                .postId(post.getId())
-                .ownerId(appointment.getOwner().getId())
-                .borrowerId(appointment.getRequester().getId())
-                .type(post.getPostType())
-                .rentalDate(appointment.getRentalDate())
-                .returnDate(appointment.getReturnDate())
-                .rentalLocation(appointment.getRentalLocation())
-                .returnLocation(appointment.getReturnLocation())
-                .price(appointment.getPrice())
-                .deposit(appointment.getDeposit())
-                .build();
+        return AppointmentRes.from(appointment, post);
     }
 
     /// 공통 로직

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -578,7 +578,8 @@ public class AppointmentService
         return AppointmentRes.from(appointment, post);
     }
 
-    // (확정/대여중/완료) 상태인 약속 페이지 조회
+    // 나의 PICK 페이지 조회
+    // 요청자가 requester인 (확정/대여중/완료) 상태의 약속 페이지 조회
     public AppointmentPageRes findMyPick(User requester,
                                          Pageable pageable,
                                          PostType type,

--- a/src/main/java/com/airfryer/repicka/domain/item_image/ItemImageService.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/ItemImageService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +38,8 @@ public class ItemImageService {
     }
 
     public ItemImage getThumbnail(Item item) {
-        return itemImageRepository.findByDisplayOrderAndItemId(1, item.getId());
+        Optional<ItemImage> itemImageOptional = itemImageRepository.findByDisplayOrderAndItemId(1, item.getId());
+        return itemImageOptional.orElse(null);
     }
 
     public List<ItemImage> getItemImages(Item item) {

--- a/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/item_image/repository/ItemImageRepository.java
@@ -4,11 +4,12 @@ import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ItemImageRepository extends JpaRepository<ItemImage, Long>
 {
     // 상품 별 대표 이미지 찾기
-    ItemImage findByDisplayOrderAndItemId(Integer displayOrder, Long itemId);
+    Optional<ItemImage> findByDisplayOrderAndItemId(Integer displayOrder, Long itemId);
 
     // 상품 별 이미지 목록 찾기
     List<ItemImage> findAllByItemId(Long itemId);


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#14 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->

### 나의 PICK 조회 API 구현

<br>

**호출 경로** : (GET) /api/v1/appointment/my-pick

**쿼리스트링**
- **page** : 페이지 번호
- **size** : 페이지 크기
- **type** : 약속 타입
    - RENTAL (대여)
    - SALE (구매)
- **period** : 검색 기간
    - YEAR (1년)
    - SIX_MONTH (6개월)
    - WEEK (일주일)

<br>

응답으로 오는 appointmentInfoList는 다음과 같은 기준으로 정렬됩니다.
- 약속 상태 기준 : CONFIRMED (확정) > IN_PROGRESS (대여중) > SUCCESS (완료)
- 동일한 약속 상태 내에서는 대여(구매) 일시 내림차순

<br>

### 그 외의 변경 사항

- @RequestParam 누락 예외 처리 핸들러 추가
- Appointment 엔티티의 대여자(구매자) 컬럼명이 미처 수정되어 있지 않던 부분 변경
- 약속 확정 시, 해당 약속이 제시 중인 상태가 아니면 모두 예외를 반환하도록 수정

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->

<br>