### PR TITLE
[FEAT#44]: 일주일이 지난 PENDING 약속 자동 만료 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ dependencies {
 	// S3
 	implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1')
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
+	// Spring Batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+	testImplementation 'org.springframework.batch:spring-batch-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/airfryer/repicka/RepickaApplication.java
+++ b/src/main/java/com/airfryer/repicka/RepickaApplication.java
@@ -1,11 +1,16 @@
 package com.airfryer.repicka;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableJpaAuditing
+@EnableJpaAuditing			// Auditing 사용
+@EnableBatchProcessing      // Spring Batch 사용
+@EnableScheduling           // Spring Scheduler 사용
 public class RepickaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/airfryer/repicka/common/batch/configuration/ExpireAppointmentConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/batch/configuration/ExpireAppointmentConfig.java
@@ -1,0 +1,106 @@
+package com.airfryer.repicka.common.batch.configuration;
+
+import com.airfryer.repicka.domain.appointment.entity.Appointment;
+import com.airfryer.repicka.domain.appointment.entity.AppointmentState;
+import com.airfryer.repicka.domain.appointment.entity.UpdateInProgressAppointment;
+import com.airfryer.repicka.domain.appointment.repository.AppointmentRepository;
+import com.airfryer.repicka.domain.appointment.repository.UpdateInProgressAppointmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+// 일주일 지난 PENDING 상태의 약속을 만료시키는 Spring Batch 설정
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class ExpireAppointmentConfig
+{
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final AppointmentRepository appointmentRepository;
+    private final UpdateInProgressAppointmentRepository updateInProgressAppointmentRepository;
+
+    // 약속 만료 Job
+    @Bean
+    public Job expireAppointmentJob()
+    {
+        return new JobBuilder("expireAppointmentJob", jobRepository)
+                .start(expireAppointmentStep())
+                .build();
+    }
+
+    // 약속 만료 Step
+    @Bean
+    public Step expireAppointmentStep()
+    {
+        return new StepBuilder("expireAppointmentStep", jobRepository)
+                .<Appointment, Appointment>chunk(100, transactionManager)
+                .reader(expireAppointmentReader())
+                .writer(expireAppointmentWriter())
+                .build();
+    }
+
+    // 약속 만료 reader
+    @Bean
+    @StepScope
+    public ItemReader<Appointment> expireAppointmentReader()
+    {
+        // updatedAt 일시가 일주일 이전인 Appointment 조회
+        return new RepositoryItemReaderBuilder<Appointment>()
+                .repository(appointmentRepository)
+                .methodName("findByStateAndUpdatedAtBefore")
+                .arguments(List.of(AppointmentState.PENDING, LocalDateTime.now().minusWeeks(1)))
+                .pageSize(100)
+                .sorts(Map.of("updatedAt", Sort.Direction.ASC))
+                .name("expireAppointmentReader")
+                .build();
+    }
+
+    // PENDING 약속 만료 writer
+    @Bean
+    public ItemWriter<Appointment> expireAppointmentWriter() {
+        return appointments -> {
+
+            /// 1. 약속 상태를 EXPIRED로 변경
+            /// 2. 연관된 UpdateInProgressAppointment 데이터 삭제
+
+            // 삭제할 UpdateInProgressAppointment 데이터
+            List<UpdateInProgressAppointment> deleteList = new ArrayList<>();
+
+            // 각 약속 데이터 순회
+            for(Appointment appointment : appointments)
+            {
+                // 약속 만료
+                appointment.expire();
+
+                // 해당 약속에 대한 UpdateInProgressAppointment 데이터 삭제
+                List<UpdateInProgressAppointment> data = updateInProgressAppointmentRepository.findByAppointmentId(appointment.getId());
+                deleteList.addAll(data);
+            }
+
+            updateInProgressAppointmentRepository.deleteAll(deleteList);
+            appointmentRepository.saveAll(appointments);
+
+        };
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/batch/scheduler/ExpireAppointmentScheduler.java
+++ b/src/main/java/com/airfryer/repicka/common/batch/scheduler/ExpireAppointmentScheduler.java
@@ -4,14 +4,12 @@ import com.airfryer.repicka.common.exception.CustomException;
 import com.airfryer.repicka.common.exception.CustomExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Component
 @RequiredArgsConstructor
@@ -21,7 +19,7 @@ public class ExpireAppointmentScheduler
     private final Job expireAppointmentJob;
 
     // 매일 오전 4시에 실행
-    @Scheduled(cron = "* * 4 * * *")
+    @Scheduled(cron = "0 0 4 * * *")
     public void run()
     {
         try {

--- a/src/main/java/com/airfryer/repicka/common/batch/scheduler/ExpireAppointmentScheduler.java
+++ b/src/main/java/com/airfryer/repicka/common/batch/scheduler/ExpireAppointmentScheduler.java
@@ -3,6 +3,7 @@ package com.airfryer.repicka.common.batch.scheduler;
 import com.airfryer.repicka.common.exception.CustomException;
 import com.airfryer.repicka.common.exception.CustomExceptionCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ExpireAppointmentScheduler
 {
     private final JobLauncher jobLauncher;
@@ -27,7 +29,7 @@ public class ExpireAppointmentScheduler
                     .addString("now", LocalDateTime.now().toString())
                     .toJobParameters());
         } catch (Exception e) {
-            throw new CustomException(CustomExceptionCode.SPRING_SCHEDULER_ERROR, e.getMessage());
+            log.error(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/airfryer/repicka/common/batch/scheduler/ExpireAppointmentScheduler.java
+++ b/src/main/java/com/airfryer/repicka/common/batch/scheduler/ExpireAppointmentScheduler.java
@@ -1,0 +1,35 @@
+package com.airfryer.repicka.common.batch.scheduler;
+
+import com.airfryer.repicka.common.exception.CustomException;
+import com.airfryer.repicka.common.exception.CustomExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@RequiredArgsConstructor
+public class ExpireAppointmentScheduler
+{
+    private final JobLauncher jobLauncher;
+    private final Job expireAppointmentJob;
+
+    // 매일 오전 4시에 실행
+    @Scheduled(cron = "* * 4 * * *")
+    public void run()
+    {
+        try {
+            jobLauncher.run(expireAppointmentJob, new JobParametersBuilder()
+                    .addString("now", LocalDateTime.now().toString())
+                    .toJobParameters());
+        } catch (Exception e) {
+            throw new CustomException(CustomExceptionCode.SPRING_SCHEDULER_ERROR, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -61,8 +61,7 @@ public enum CustomExceptionCode
 
     // 내부 로직 오류 (발생하면 안됨!)
     SALE_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "제품은 판매 예정인데, 판매 게시글 데이터를 찾을 수 없습니다. (내부 로직 오류)"),
-    SALE_APPOINTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "제품은 판매 예정인데, 판매 약속 데이터를 찾을 수 없습니다. (내부 로직 오류)"),
-    SPRING_SCHEDULER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Spring Scheduler 작동 중 에러가 발생하였습니다.");
+    SALE_APPOINTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "제품은 판매 예정인데, 판매 약속 데이터를 찾을 수 없습니다. (내부 로직 오류)");
 
     private final HttpStatus httpStatus;    // HTTP 상태 코드
     private final String message;           // 메시지

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -61,7 +61,8 @@ public enum CustomExceptionCode
 
     // 내부 로직 오류 (발생하면 안됨!)
     SALE_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "제품은 판매 예정인데, 판매 게시글 데이터를 찾을 수 없습니다. (내부 로직 오류)"),
-    SALE_APPOINTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "제품은 판매 예정인데, 판매 약속 데이터를 찾을 수 없습니다. (내부 로직 오류)");
+    SALE_APPOINTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "제품은 판매 예정인데, 판매 약속 데이터를 찾을 수 없습니다. (내부 로직 오류)"),
+    SPRING_SCHEDULER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Spring Scheduler 작동 중 에러가 발생하였습니다.");
 
     private final HttpStatus httpStatus;    // HTTP 상태 코드
     private final String message;           // 메시지

--- a/src/main/java/com/airfryer/repicka/domain/appointment/entity/Appointment.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/entity/Appointment.java
@@ -150,4 +150,10 @@ public class Appointment extends BaseEntity
                 .state(this.state)
                 .build();
     }
+
+    /// 약속 만료
+
+    public void expire() {
+        this.state = AppointmentState.EXPIRED;
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
@@ -101,6 +101,6 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long>
                                                    @Param("type") PostType type,
                                                    @Param("start") LocalDateTime start);
 
-    // 레코드 수정 날짜가 특정 시점 이전인 특정 상태의 약속 리스트 조회
-    List<Appointment> findByStateAndUpdatedAtBefore(AppointmentState state, LocalDateTime localDateTime);
+    // 레코드 수정 날짜가 특정 시점 이전인 특정 상태의 약속 페이지 조회
+    Page<Appointment> findByStateAndUpdatedAtBefore(AppointmentState state, LocalDateTime localDateTime, Pageable pageable);
 }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
@@ -101,6 +101,6 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long>
                                                    @Param("type") PostType type,
                                                    @Param("start") LocalDateTime start);
 
-    // 레코드 수정 날짜가 특정 시점 이전인 약속 리스트 조회
-    List<Appointment> findByUpdatedAtBefore(LocalDateTime localDateTime);
+    // 레코드 수정 날짜가 특정 시점 이전인 특정 상태의 약속 리스트 조회
+    List<Appointment> findByStateAndUpdatedAtBefore(AppointmentState state, LocalDateTime localDateTime);
 }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/repository/AppointmentRepository.java
@@ -100,4 +100,7 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long>
                                                    @Param("ownerId") Long ownerId,
                                                    @Param("type") PostType type,
                                                    @Param("start") LocalDateTime start);
+
+    // 레코드 수정 날짜가 특정 시점 이전인 약속 리스트 조회
+    List<Appointment> findByUpdatedAtBefore(LocalDateTime localDateTime);
 }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/repository/UpdateInProgressAppointmentRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/repository/UpdateInProgressAppointmentRepository.java
@@ -4,11 +4,15 @@ import com.airfryer.repicka.domain.appointment.entity.UpdateInProgressAppointmen
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UpdateInProgressAppointmentRepository extends JpaRepository<UpdateInProgressAppointment, Long>
 {
+    // 약속 ID로 대여중 약속 변경 요청 데이터 조회
+    List<UpdateInProgressAppointment> findByAppointmentId(Long appointmentId);
+
     // 약속 ID, 생성한 사용자 ID로 대여중 약속 변경 요청 데이터 조회
     Optional<UpdateInProgressAppointment> findByAppointmentIdAndCreatorId(Long appointmentId, Long creatorId);
 }


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#44 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
**Spring Batch와 Spring Schduler**를 통해 **updatedAt** 일자가 현재를 기준으로 일주일 지난 **Appointment**에 대해 다음 작업을 수행합니다.
- 상태를 EXPIRED로 변경
- 연관된 UpdateInProgressAppointment 제거 (존재할리가 없지만, 예기치 못한 동작으로 인해 쓰레기 값이 남았을 경우를 대비)

<br/>

참고로, Spring Batch는 다음 총 6개의 기본 테이블을 기본적으로 사용합니다.
- batch_job_execution
- batch_job_execution_context
- batch_job_execution_params
- batch_job_instance
- batch_step_execution
- batch_step_execution_context

이전 버전에서는 application.yml 설정으로 해당 테이블을 데이터베이스에 자동으로 추가할 수 있었지만, 최신 버전에서는 그게 안되더군요..
그래서 라이브러리 내에 있는 **schema-postgresql.sql** 파일의 sql 문을 서버 데이터베이스에 명시적으로 입력하였습니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- 약속 자동 종료 기능 구현

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>