### PR TITLE
[FEAT#37]: 게시글 좋아요 기능 및 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/security/jwt/JwtFilter.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/JwtFilter.java
@@ -1,7 +1,6 @@
 package com.airfryer.repicka.common.security.jwt;
 
 import com.airfryer.repicka.common.security.oauth2.CustomOAuth2User;
-import com.airfryer.repicka.common.security.oauth2.CustomOAuth2UserService;
 import com.airfryer.repicka.domain.user.entity.User;
 import com.airfryer.repicka.domain.user.repository.UserRepository;
 import jakarta.servlet.FilterChain;
@@ -23,7 +22,6 @@ import java.io.IOException;
 public class JwtFilter extends OncePerRequestFilter
 {
     private final JwtUtil jwtUtil;
-    private final CustomOAuth2UserService customOAuth2UserService;
     private final UserRepository userRepository;
 
     @Override

--- a/src/main/java/com/airfryer/repicka/domain/appointment/controller/AppointmentController.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/controller/AppointmentController.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,7 +27,6 @@ public class AppointmentController
 
     // 대여 게시글에서 약속 제시
     @PostMapping("/in-rental-post")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> offerAppointmentInRentalPost(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                            @RequestBody @Valid OfferAppointmentInRentalPostReq dto)
     {
@@ -45,7 +43,6 @@ public class AppointmentController
 
     // 판매 게시글에서 약속 제시
     @PostMapping("/in-sale-post")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> offerAppointmentInSalePost(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                          @RequestBody @Valid OfferAppointmentInSalePostReq dto)
     {
@@ -64,7 +61,6 @@ public class AppointmentController
 
     // 약속 확정
     @PatchMapping("/{appointmentId}/confirm")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> confirmAppointment(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                  @PathVariable Long appointmentId)
     {
@@ -80,7 +76,6 @@ public class AppointmentController
 
     // 약속 취소
     @PatchMapping("/{appointmentId}/cancel")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> cancelAppointment(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                 @PathVariable Long appointmentId)
     {
@@ -97,7 +92,6 @@ public class AppointmentController
     // 내가 requester인 약속 페이지 조회 (나의 PICK 조회)
     // 요청자가 requester인 (확정/대여중/완료) 상태의 약속 페이지 조회
     @GetMapping("/requester")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> findMyAppointmentPageAsRequester(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                                Pageable pageable,
                                                                                @RequestParam PostType type,
@@ -122,7 +116,6 @@ public class AppointmentController
     // 내가 owner인 약속 페이지 조회
     // 요청자가 owner인 (확정/대여중/완료) 상태의 약속 페이지 조회
     @GetMapping("/owner")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> findMyAppointmentPageAsOwner(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                            Pageable pageable,
                                                                            @RequestParam PostType type,
@@ -146,7 +139,6 @@ public class AppointmentController
 
     // 확정된 약속 변경 제시
     @PatchMapping("/confirmed")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> offerToUpdateConfirmedAppointment(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                                 @RequestBody @Valid OfferToUpdateConfirmedAppointmentReq dto)
     {

--- a/src/main/java/com/airfryer/repicka/domain/appointment/controller/UpdateInProgressAppointmentController.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/controller/UpdateInProgressAppointmentController.java
@@ -11,7 +11,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,7 +23,6 @@ public class UpdateInProgressAppointmentController
 
     // 대여 중인 약속 변경 제시
     @PostMapping()
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> offerToUpdateInProgressAppointment(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                                  @RequestBody @Valid OfferToUpdateInProgressAppointmentReq dto)
     {
@@ -40,7 +38,6 @@ public class UpdateInProgressAppointmentController
 
     // 대여 중인 약속 변경 제시 데이터 조회
     @GetMapping()
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> findOfferToUpdateInProgressAppointment(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                                      @RequestParam Long appointmentId,
                                                                                      @RequestParam Boolean isMine)
@@ -57,7 +54,6 @@ public class UpdateInProgressAppointmentController
 
     // 대여 중인 약속 변경 제시 수락 및 거절
     @PatchMapping("/{updateInProgressAppointmentId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> acceptOfferToUpdateInProgressAppointment(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                                        @PathVariable Long updateInProgressAppointmentId,
                                                                                        @RequestParam Boolean isAccepted)
@@ -74,7 +70,6 @@ public class UpdateInProgressAppointmentController
 
     // 대여 중인 약속 변경 제시 취소
     @DeleteMapping("/{updateInProgressAppointmentId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> deleteOfferToUpdateInProgressAppointment(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
                                                                                        @PathVariable Long updateInProgressAppointmentId)
     {

--- a/src/main/java/com/airfryer/repicka/domain/post/PostController.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/PostController.java
@@ -14,7 +14,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,8 +28,7 @@ import java.util.Map;
 public class PostController {
     private final PostService postService;
 
-    @GetMapping("/presigned-url")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
+    @GetMapping("/presigned-url")    
     public ResponseEntity<SuccessResponseDto> getPresignedUrl(@AuthenticationPrincipal CustomOAuth2User user,
                                                               @Valid PresignedUrlReq req) {
         PresignedUrlRes presignedUrlRes = postService.getPresignedUrl(req, user.getUser());
@@ -43,7 +41,6 @@ public class PostController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> createPost(@AuthenticationPrincipal CustomOAuth2User user,
                                                          @Valid @RequestBody CreatePostReq req) {
         List<PostDetailRes> postDetailResList = postService.createPostWithItemAndImages(req, user.getUser());
@@ -56,7 +53,6 @@ public class PostController {
     }
 
     @PutMapping("/{postId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> updatePost(@AuthenticationPrincipal CustomOAuth2User user,
                                                           @PathVariable(value="postId") Long postId,
                                                           @Valid @RequestBody CreatePostReq req) {
@@ -70,7 +66,6 @@ public class PostController {
     }
 
     @DeleteMapping("/{postId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> deletePost(@AuthenticationPrincipal CustomOAuth2User user,
                                                           @PathVariable(value="postId") Long postId) {
         postService.deletePost(postId, user.getUser());
@@ -82,7 +77,6 @@ public class PostController {
     }
 
     @GetMapping("/{postId}")
-    @PreAuthorize("permitAll()")
     public ResponseEntity<SuccessResponseDto> getPostDetail(@PathVariable(value="postId") Long postId,
                                                            @AuthenticationPrincipal CustomOAuth2User user) {
         
@@ -97,7 +91,6 @@ public class PostController {
     }
 
     @PatchMapping("/{postId}/repost")
-    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<SuccessResponseDto> repostPost(@AuthenticationPrincipal CustomOAuth2User user,
                                                           @PathVariable(value="postId") Long postId) {
         LocalDateTime repostDate = postService.repostPost(postId, user.getUser());
@@ -110,7 +103,6 @@ public class PostController {
     }
 
     @GetMapping("/search")
-    @PreAuthorize("permitAll()")
     public ResponseEntity<SuccessResponseDto> searchPostList(@Valid SearchPostReq req) {
         List<PostPreviewRes> postPreviewResList = postService.searchPostList(req);
 
@@ -123,7 +115,6 @@ public class PostController {
 
     // 월 단위로 날짜별 제품 대여 가능 여부 조회
     @GetMapping("/{postId}/rental-availability")
-    @PreAuthorize("permitAll()")
     public ResponseEntity<SuccessResponseDto> getItemRentalAvailability(@PathVariable Long postId,
                                                                         @RequestParam int year,
                                                                         @RequestParam int month)
@@ -139,7 +130,6 @@ public class PostController {
 
     // 제품 구매가 가능한 첫 날짜 조회
     @GetMapping("/{postId}/sale-availability")
-    @PreAuthorize("permitAll()")
     public ResponseEntity<SuccessResponseDto> getItemSaleAvailability(@PathVariable Long postId)
     {
         LocalDate data = postService.getItemSaleAvailability(postId);

--- a/src/main/java/com/airfryer/repicka/domain/post/dto/PostDetailRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/post/dto/PostDetailRes.java
@@ -41,8 +41,10 @@ public class PostDetailRes {
 
     private boolean isMine; // 내 게시글 여부
 
+    private boolean isLiked; // 좋아요 여부
+
     // post, imageUrls, currentUser로 PostDetailRes 반환하는 정적 팩토리 메서드
-    public static PostDetailRes from(Post post, List<String> imageUrls, User currentUser) {
+    public static PostDetailRes from(Post post, List<String> imageUrls, User currentUser, boolean isLiked) {
         boolean isMine = currentUser != null && currentUser.getId().equals(post.getWriter().getId());
 
         return PostDetailRes.builder()
@@ -57,6 +59,7 @@ public class PostDetailRes {
                 .likeCount(post.getLikeCount())
                 .chatRoomCount(post.getChatRoomCount())
                 .isMine(isMine)
+                .isLiked(isLiked)
                 .build();
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/post_like/PostLikeController.java
+++ b/src/main/java/com/airfryer/repicka/domain/post_like/PostLikeController.java
@@ -1,0 +1,45 @@
+package com.airfryer.repicka.domain.post_like;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.airfryer.repicka.domain.post_like.dto.PostLikeRes;
+import com.airfryer.repicka.common.response.SuccessResponseDto;
+import com.airfryer.repicka.common.security.oauth2.CustomOAuth2User;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/like")
+@RequiredArgsConstructor
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @PostMapping("/{postId}")
+    public ResponseEntity<SuccessResponseDto> likePost(@PathVariable(value="postId") Long postId,
+                                                        @AuthenticationPrincipal CustomOAuth2User user) {
+        boolean isLiked = postLikeService.likePost(postId, user.getUser());
+
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+            .message(isLiked ? "게시글 좋아요를 성공적으로 추가했습니다." : "게시글 좋아요를 성공적으로 취소했습니다.")
+            .build());
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto> getPostLikes(@AuthenticationPrincipal CustomOAuth2User user) {
+
+        List<PostLikeRes> postLikes = postLikeService.getPostLikes(user.getUser());
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+            .message("게시글 좋아요 목록을 성공적으로 조회했습니다.")
+            .data(postLikes)
+            .build());
+    }
+}

--- a/src/main/java/com/airfryer/repicka/domain/post_like/PostLikeService.java
+++ b/src/main/java/com/airfryer/repicka/domain/post_like/PostLikeService.java
@@ -37,6 +37,10 @@ public class PostLikeService {
         if (existingLike.isPresent()) {
             // 이미 좋아요를 눌렀으면 좋아요 취소
             postLikeRepository.delete(existingLike.get());
+
+            // 좋아요 취소 시 좋아요 수 감소
+            post.removeLikeCount();
+
             return false;
         }
         else {
@@ -47,6 +51,10 @@ public class PostLikeService {
                 .build();
             
             postLikeRepository.save(postLike);
+
+            // 좋아요 추가 시 좋아요 수 증가
+            post.addLikeCount();
+
             return true;
         }
     }

--- a/src/main/java/com/airfryer/repicka/domain/post_like/PostLikeService.java
+++ b/src/main/java/com/airfryer/repicka/domain/post_like/PostLikeService.java
@@ -1,0 +1,69 @@
+package com.airfryer.repicka.domain.post_like;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.airfryer.repicka.domain.post_like.dto.PostLikeRes;
+import com.airfryer.repicka.domain.post_like.entity.PostLike;
+import com.airfryer.repicka.domain.post_like.repository.PostLikeRepository;
+import com.airfryer.repicka.domain.item_image.ItemImageService; 
+import com.airfryer.repicka.domain.item.entity.Item;
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post.repository.PostRepository;
+import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.common.exception.CustomException;
+import com.airfryer.repicka.common.exception.CustomExceptionCode;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final ItemImageService itemImageService;
+
+    @Transactional
+    public boolean likePost(Long postId, User user) {
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(CustomExceptionCode.POST_NOT_FOUND, postId));
+        
+        Optional<PostLike> existingLike = postLikeRepository.findByPostAndLiker(post, user);
+        if (existingLike.isPresent()) {
+            // 이미 좋아요를 눌렀으면 좋아요 취소
+            postLikeRepository.delete(existingLike.get());
+            return false;
+        }
+        else {
+            // 좋아요를 누르지 않았으면 좋아요 추가
+            PostLike postLike = PostLike.builder()
+                .post(post)
+                .liker(user)
+                .build();
+            
+            postLikeRepository.save(postLike);
+            return true;
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostLikeRes> getPostLikes(User user) {
+        List<PostLike> postLikes = postLikeRepository.findByLiker(user);
+
+        // 모든 Item의 썸네일 배치 조회
+        List<Item> items = postLikes.stream()
+            .map(PostLike::getPost)
+            .map(Post::getItem)
+            .toList();
+        Map<Long, String> thumbnailMap = itemImageService.getThumbnailsForItems(items);
+
+        return postLikes.stream()
+            .map(postLike -> PostLikeRes.from(postLike.getPost(), thumbnailMap.get(postLike.getPost().getItem().getId())))
+            .toList();
+    }
+}

--- a/src/main/java/com/airfryer/repicka/domain/post_like/dto/PostLikeRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/post_like/dto/PostLikeRes.java
@@ -1,0 +1,39 @@
+package com.airfryer.repicka.domain.post_like.dto;
+
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post.entity.PostType;
+import com.airfryer.repicka.domain.item.entity.ProductType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostLikeRes {
+    private Long id;
+
+    private PostType postType; // 게시글 타입
+
+    private String title; // 게시글 제목
+
+    @Builder.Default
+    private ProductType[] productTypes = new ProductType[2]; // 제품 타입
+
+    private String thumbnail; // 대표 사진
+
+    private int price; // 대여료 / 판매값
+    
+    private int deposit; // 보증금
+
+    public static PostLikeRes from(Post post, String thumbnailUrl) {
+        return PostLikeRes.builder()
+            .id(post.getId())
+            .postType(post.getPostType())
+            .title(post.getItem().getTitle())
+            .productTypes(post.getItem().getProductTypes())
+            .thumbnail(thumbnailUrl)
+            .price(post.getPrice())
+            .deposit(post.getDeposit())
+            .build();
+    }
+}

--- a/src/main/java/com/airfryer/repicka/domain/post_like/repository/PostLikeRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/post_like/repository/PostLikeRepository.java
@@ -1,7 +1,20 @@
 package com.airfryer.repicka.domain.post_like.repository;
 
-import com.airfryer.repicka.domain.post_like.entity.PostLike;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.airfryer.repicka.domain.post.entity.Post;
+import com.airfryer.repicka.domain.post_like.entity.PostLike;
+import com.airfryer.repicka.domain.user.entity.User;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    Optional<PostLike> findByPostAndLiker(Post post, User user);
+
+    @Query("SELECT pl FROM PostLike pl JOIN FETCH pl.post JOIN FETCH pl.post.item WHERE pl.liker = :user")
+    List<PostLike> findByLiker(@Param("user") User user);
 }


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#37 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
### 게시글 좋아요
API **POST /api/v1/like/{postId}**
- 유저가 게시글을 이미 좋아요 했는지 확인 후 이미 좋아요했으면 엔터티 삭제, 좋아한 적이 없으면 새로운 엔터티를 등록합니다.
- 이에 따른 메세지를 응답합니다.

### 좋아요 한 게시글 목록 조회
API **GET /api/v1/like**
- 유저에 따라 좋아요 한 게시글의 Preview 목록을 완성하기 위해 FETCH JOIN, 배치 조회를 진행합니다.
- 클라이언트에 유저가 좋아요 한 게시글 목록을 반환합니다.


<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- 게시글 상세 페이지에서 isLiked 추가
- 게시글 좋아요 목록에서도 태그 모두 추가

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>