### PR TITLE
[FEAT#60]: 약속 리마인드 알림 구현

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v4
 
+      - name: Restore Firebase Admin SDK file
+        run: |
+          mkdir -p ./src/main/resources/firebase
+          echo "${{ secrets.FIREBASE_ADMIN_SDK_FILE }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -73,11 +78,6 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v4
       
-      - name: Restore Firebase Admin SDK file
-        run: |
-          mkdir -p ./src/main/resources/firebase
-          echo "${{ secrets.FIREBASE_ADMIN_SDK_FILE }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Restore Firebase Admin SDK file
         run: |
           mkdir -p ./src/main/resources/firebase
-          echo "${{ secrets.FIREBASE_ADMIN_SDK_FILE }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
+          echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -132,7 +132,7 @@ jobs:
       - name: Restore Firebase Admin SDK file
         run: |
           mkdir -p ./src/main/resources/firebase
-          echo "${{ secrets.FIREBASE_ADMIN_SDK_FILE }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
+          echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
 
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u kyeahxx19 --password-stdin

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Restore Firebase Admin SDK file
         run: |
-          mkdir -p ./src/main/resources/firebase
+          mkdir -p ./build/resources/main/firebase
           echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Restore Firebase Admin SDK file
         run: |
-          mkdir -p ./src/main/resources/firebase
+          mkdir -p ./build/resources/main/firebase
           echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./build/resources/main/firebase/firebase-admin-sdk.json
 
       - name: Set up JDK 21
@@ -131,7 +131,7 @@ jobs:
 
       - name: Restore Firebase Admin SDK file
         run: |
-          mkdir -p ./build/resources/main/firebase
+          mkdir -p ./src/main/resources/firebase
           echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Restore Firebase Admin SDK file
         run: |
-          mkdir -p ./build/resources/main/firebase
-          echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./build/resources/main/firebase/firebase-admin-sdk.json
+          mkdir -p ./src/main/resources/firebase
+          echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./src/main/resources/firebase/repicka-firebase-adminsdk.json
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -132,7 +132,7 @@ jobs:
       - name: Restore Firebase Admin SDK file
         run: |
           mkdir -p ./src/main/resources/firebase
-          echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
+          echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./src/main/resources/firebase/repicka-firebase-adminsdk.json
 
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u kyeahxx19 --password-stdin

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,6 +36,14 @@ jobs:
           MONGO_INITDB_ROOT_USERNAME: ${{ secrets.TEST_MONGODB_USERNAME }}
           MONGO_INITDB_ROOT_PASSWORD: ${{ secrets.TEST_MONGODB_PASSWORD }}
 
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        env:
+          REDIS_HOST: ${{ secrets.REDIS_HOST }}
+          REDIS_PORT: ${{ secrets.REDIS_PORT }}
+
     env:
       TEST_DB_URL: ${{ secrets.TEST_DB_URL }}
       TEST_DB_USERNAME: ${{ secrets.TEST_DB_USERNAME }}
@@ -44,6 +52,8 @@ jobs:
       TEST_MONGODB_USERNAME: ${{ secrets.TEST_MONGODB_USERNAME }}
       TEST_MONGODB_PASSWORD: ${{ secrets.TEST_MONGODB_PASSWORD }}
       TEST_MONGODB_DATABASE: ${{ secrets.TEST_MONGODB_DATABASE }}
+      REDIS_HOST: ${{ secrets.REDIS_HOST }}
+      REDIS_PORT: ${{ secrets.REDIS_PORT }}
       JWT_SECRET: ${{ secrets.TEST_JWT_SECRET }}
       FRONTEND_URI: ${{ secrets.TEST_FRONTEND_URI }}
 
@@ -128,6 +138,8 @@ jobs:
           echo "MONGODB_USERNAME=${{ secrets.MONGODB_USERNAME }}" >> .env
           echo "MONGODB_PASSWORD=${{ secrets.MONGODB_PASSWORD }}" >> .env
           echo "MONGODB_DATABASE=${{ secrets.MONGODB_DATABASE }}" >> .env
+          echo "REDIS_HOST=${{ secrets.REDIS_HOST }}" >> .env
+          echo "REDIS_PORT=${{ secrets.REDIS_PORT }}" >> .env
 
       - name: Restore Firebase Admin SDK file
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,6 +72,11 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
+      
+      - name: Restore Firebase Admin SDK file
+        run: |
+          mkdir -p ./src/main/resources/firebase
+          echo "${{ secrets.FIREBASE_ADMIN_SDK_FILE }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -123,6 +128,11 @@ jobs:
           echo "MONGODB_USERNAME=${{ secrets.MONGODB_USERNAME }}" >> .env
           echo "MONGODB_PASSWORD=${{ secrets.MONGODB_PASSWORD }}" >> .env
           echo "MONGODB_DATABASE=${{ secrets.MONGODB_DATABASE }}" >> .env
+
+      - name: Restore Firebase Admin SDK file
+        run: |
+          mkdir -p ./src/main/resources/firebase
+          echo "${{ secrets.FIREBASE_ADMIN_SDK_FILE }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
 
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u kyeahxx19 --password-stdin

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Restore Firebase Admin SDK file
         run: |
           mkdir -p ./src/main/resources/firebase
-          echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./src/main/resources/firebase/firebase-admin-sdk.json
+          echo "${{ secrets.FIREBASE_ADMIN_JSON }}" | base64 -d > ./build/resources/main/firebase/firebase-admin-sdk.json
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docker-compose.yml
 
 ## .env 파일
 .env
+**/repicka-firebase-adminsdk.json

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,9 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Firebase Cloud Messaging
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,9 @@ dependencies {
 
 	// .env 파일 지원
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/airfryer/repicka/common/configuration/FirebaseConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/configuration/FirebaseConfig.java
@@ -1,0 +1,39 @@
+package com.airfryer.repicka.common.configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.config.path}")
+    private String firebaseConfigPath;
+
+    @PostConstruct
+    public void initializeFirebase() throws IOException {
+        if (FirebaseApp.getApps().isEmpty()) {
+            GoogleCredentials googleCredentials = GoogleCredentials
+                    .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream());
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(googleCredentials)
+                    .build();
+
+            FirebaseApp.initializeApp(options);
+        }
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        return FirebaseMessaging.getInstance();
+    }
+} 

--- a/src/main/java/com/airfryer/repicka/common/configuration/RedisConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/configuration/RedisConfig.java
@@ -1,0 +1,76 @@
+package com.airfryer.repicka.common.configuration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import jakarta.annotation.PostConstruct;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        
+        // String Serializer for keys
+        StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
+        // JSON Serializer for values (Object 저장)
+        GenericJackson2JsonRedisSerializer jsonRedisSerializer = new GenericJackson2JsonRedisSerializer();
+        
+        // Key Serializers
+        redisTemplate.setKeySerializer(stringRedisSerializer);
+        redisTemplate.setHashKeySerializer(stringRedisSerializer);
+        
+        // Value Serializers
+        redisTemplate.setValueSerializer(jsonRedisSerializer);
+        redisTemplate.setHashValueSerializer(jsonRedisSerializer);
+        
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
+    }
+    
+    // Redis 키 만료 이벤트를 위한 메시지 리스너 컨테이너
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory) {
+        
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        
+        return container;
+    }
+    
+    // Redis Keyspace Notifications 자동 활성화
+    @PostConstruct
+    public void enableKeyspaceNotifications() {
+        try {
+            RedisTemplate<String, Object> template = redisTemplate();
+            // Redis Keyspace Notifications 활성화 (키 만료 이벤트)
+            template.execute((org.springframework.data.redis.core.RedisCallback<Void>) connection -> {
+                connection.serverCommands().setConfig("notify-keyspace-events", "Ex");
+                log.info("Redis Keyspace Notifications 활성화됨: Ex (키 만료 이벤트)");
+                return null;
+            });
+        } catch (Exception e) {
+            log.warn("Redis Keyspace Notifications 활성화 실패 - 수동으로 설정하세요: CONFIG SET notify-keyspace-events Ex", e);
+        }
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/firebase/dto/FCMNotificationReq.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/dto/FCMNotificationReq.java
@@ -1,0 +1,36 @@
+package com.airfryer.repicka.common.firebase.dto;
+
+import com.airfryer.repicka.common.firebase.type.NotificationType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FCMNotificationReq {
+    private NotificationType notificationType;
+    private Object relatedId;  // appointmentId(Long) 또는 chatId(ObjectId) 등
+    private String relatedName;  // 약속 관련 아이템 이름 또는 채팅 상대 이름
+    
+    // 제목 생성
+    public String getTitle() {
+        return notificationType.getTitle();
+    }
+    
+    // 내용 생성  
+    public String getBody() {
+        return notificationType.getFormattedBody(relatedName);
+    }
+
+    public static FCMNotificationReq of(NotificationType notificationType, Object id, String name) {
+        return FCMNotificationReq.builder()
+            .notificationType(notificationType)
+            .relatedId(id)
+            .relatedName(name)
+            .build();
+    }
+} 

--- a/src/main/java/com/airfryer/repicka/common/firebase/service/FCMService.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/service/FCMService.java
@@ -18,6 +18,10 @@ public class FCMService {
 
     // 단일 기기에 푸시 알림 전송
     public void sendNotification(String token, FCMNotificationReq request) {
+        if (token == null || token.isEmpty()) {
+            return;
+        }
+
         try {
             Message message = Message.builder()
                     .setToken(token)
@@ -38,6 +42,15 @@ public class FCMService {
 
     // 여러 기기에 푸시 알림 전송
     public void sendNotificationToMultiple(List<String> tokens, FCMNotificationReq request) {
+        // 존재하는 토큰만 필터링
+        tokens = tokens.stream()
+                .filter(token -> token != null && !token.isEmpty())
+                .toList();
+        
+        if (tokens.isEmpty()) {
+            return;
+        }
+
         try {
             MulticastMessage message = MulticastMessage.builder()
                     .addAllTokens(tokens)

--- a/src/main/java/com/airfryer/repicka/common/firebase/service/FCMService.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/service/FCMService.java
@@ -1,0 +1,58 @@
+package com.airfryer.repicka.common.firebase.service;
+
+import com.google.firebase.messaging.*;
+import com.airfryer.repicka.common.firebase.dto.FCMNotificationReq;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FCMService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    // 단일 기기에 푸시 알림 전송
+    public void sendNotification(String token, FCMNotificationReq request) {
+        try {
+            Message message = Message.builder()
+                    .setToken(token)
+                    .setNotification(Notification.builder()
+                            .setTitle(request.getTitle())
+                            .setBody(request.getBody())
+                            .build())
+                    .putData("notificationType", request.getNotificationType().name())
+                    .putData("relatedId", request.getRelatedId().toString())
+                    .build();
+
+            firebaseMessaging.send(message);
+
+        } catch (FirebaseMessagingException e) {
+            log.error("푸시 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    // 여러 기기에 푸시 알림 전송
+    public void sendNotificationToMultiple(List<String> tokens, FCMNotificationReq request) {
+        try {
+            MulticastMessage message = MulticastMessage.builder()
+                    .addAllTokens(tokens)
+                    .setNotification(Notification.builder()
+                            .setTitle(request.getTitle())
+                            .setBody(request.getBody())
+                            .build())
+                    .putData("notificationType", request.getNotificationType().name())
+                    .putData("relatedId", request.getRelatedId().toString())
+                    .build();
+
+            firebaseMessaging.sendEachForMulticast(message);
+
+        } catch (FirebaseMessagingException e) {
+            log.error("멀티캐스트 푸시 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+} 

--- a/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
@@ -1,0 +1,20 @@
+package com.airfryer.repicka.common.firebase.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+    
+    APPOINTMENT_REMINDER("약속 리마인더 알림", "'%s' PICK 약속 날짜가 다가오고 있습니다! 잊지 말고 준비해주세요."),
+    APPOINTMENT_CONFIRMATION("약속 확정 알림", "요청하신 '%s' PICK이 확정되었습니다."),
+    CHAT_MESSAGE("새로운 메시지", "'%s'님이 새로운 메시지를 보냈습니다.");
+    
+    private final String title;
+    private final String bodyFormat;
+    
+    public String getFormattedBody(String name) {
+        return String.format(this.bodyFormat, name);
+    }
+}   

--- a/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum NotificationType {
     
-    APPOINTMENT_REMINDER("약속 리마인더 알림", "'%s' PICK 약속 날짜가 다가오고 있습니다! 잊지 말고 준비해주세요."),
+    APPOINTMENT_REMINDER("약속 리마인더 알림", "'%s' PICK 날짜가 다가오고 있습니다! 잊지 말고 준비해주세요."),
     APPOINTMENT_CONFIRMATION("약속 확정 알림", "요청하신 '%s' PICK이 확정되었습니다."),
     CHAT_MESSAGE("새로운 메시지", "'%s'님이 새로운 메시지를 보냈습니다.");
     

--- a/src/main/java/com/airfryer/repicka/common/redis/DelayedQueueService.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/DelayedQueueService.java
@@ -1,6 +1,9 @@
 package com.airfryer.repicka.common.redis;
 
 import com.airfryer.repicka.common.redis.dto.AppointmentTask;
+import com.airfryer.repicka.common.firebase.dto.FCMNotificationReq;
+import com.airfryer.repicka.common.firebase.type.NotificationType;
+import com.airfryer.repicka.common.firebase.service.FCMService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +18,7 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +27,7 @@ public class DelayedQueueService {
     
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
-    
+    private final FCMService fcmService;
     private static final String DELAYED_TASK_PREFIX = "delayed:task:";
     private static final String TASK_DATA_PREFIX = "taskdata:";
     
@@ -141,6 +145,7 @@ public class DelayedQueueService {
     
     // 예약 알림 발송
     private void sendAppointmentReminder(AppointmentTask task) {
-        // TODO: 예약 알림 발송 로직
+        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_REMINDER, task.getAppointmentId(), task.getItemName());
+        fcmService.sendNotificationToMultiple(List.of(task.getOwnerFcmToken(), task.getRequesterFcmToken()), notificationReq);
     }
 } 

--- a/src/main/java/com/airfryer/repicka/common/redis/DelayedQueueService.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/DelayedQueueService.java
@@ -1,0 +1,133 @@
+package com.airfryer.repicka.common.redis;
+
+import com.airfryer.repicka.common.redis.dto.AppointmentTask;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DelayedQueueService {
+    
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+    
+    private static final String DELAYED_TASK_PREFIX = "delayed:task:";
+    private static final String TASK_DATA_PREFIX = "taskdata:";
+    
+    // 지연 작업을 Redis TTL로 등록
+    public boolean addDelayedTask(String queueName, AppointmentTask taskData, LocalDateTime executeAt) {
+        try {
+            // 의미있는 작업 ID 생성 (appointmentId 기반)
+            String taskId = queueName + ":" + taskData.getAppointmentId();
+            
+            // 실행 시간까지의 지연 시간 계산
+            long executeTimestamp = executeAt.toEpochSecond(ZoneOffset.UTC) * 1000;
+            long delayMs = executeTimestamp - System.currentTimeMillis();
+            
+            if (delayMs <= 0) {
+                // 이미 시간이 지났으면 즉시 실행
+                executeTask(taskData);
+                return true;
+            }
+            
+            // 작업 데이터를 별도로 저장
+            String taskDataKey = TASK_DATA_PREFIX + taskId;
+            String taskJson = objectMapper.writeValueAsString(taskData);
+            redisTemplate.opsForValue().set(taskDataKey, taskJson);
+            
+            // TTL 키 생성 (만료 시 이벤트 발생)
+            String delayedKey = DELAYED_TASK_PREFIX + taskId;
+            redisTemplate.opsForValue().set(
+                delayedKey, 
+                queueName, // 큐 이름 저장
+                Duration.ofMillis(delayMs)
+            );
+            
+            return true;
+            
+        } catch (JsonProcessingException e) {
+            log.error("작업 데이터 직렬화 실패", e);
+            return false;
+        }
+    }
+    
+    // Redis 키 만료 이벤트 리스너 설정
+    @Bean
+    public KeyExpirationEventMessageListener keyExpirationEventMessageListener(
+            RedisMessageListenerContainer listenerContainer) {
+        
+        return new KeyExpirationEventMessageListener(listenerContainer) {
+            @Override
+            public void onMessage(Message message, byte[] pattern) {
+                String expiredKey = message.toString();
+
+                // 지연 작업 키가 아닌 경우 처리하지 않음
+                if (!expiredKey.startsWith(DELAYED_TASK_PREFIX)) {
+                    return;
+                }
+                
+                // 작업 데이터 조회 및 실행
+                try {
+                    // 작업 ID 추출
+                    String taskId = expiredKey.substring(DELAYED_TASK_PREFIX.length());
+                    String taskDataKey = TASK_DATA_PREFIX + taskId;
+                    
+                    // 작업 데이터 조회
+                    String taskJson = (String) redisTemplate.opsForValue().get(taskDataKey);
+                    if (taskJson == null) {
+                        log.warn("작업 데이터를 찾을 수 없음: {}", taskId);
+                        return;
+                    }
+                    
+                    // 작업 실행
+                    AppointmentTask taskData = objectMapper.readValue(taskJson, AppointmentTask.class);
+                    executeTask(taskData);
+                    
+                    // 작업 데이터 정리
+                    redisTemplate.delete(taskDataKey);
+                } catch (Exception e) {
+                    log.error("키 만료 처리 중 오류: {}", expiredKey, e);
+                }
+            }
+        };
+    }
+    
+    // 작업 실행 로직
+    private void executeTask(AppointmentTask task) {
+        switch (task.getTaskType()) {
+            case "EXPIRE":
+                expireAppointment(task);
+                break;
+            case "REMIND":
+                sendAppointmentReminder(task);
+                break;
+            default:
+                log.warn("알 수 없는 작업 타입: {}", task.getTaskType());
+        }
+    }
+    
+    /// 예약 관련 비즈니스 로직 메서드들
+    
+    // 예약 만료 처리
+    private void expireAppointment(AppointmentTask task) {
+        // TODO: 예약 만료 처리 로직
+    }
+    
+    // 예약 알림 발송
+    private void sendAppointmentReminder(AppointmentTask task) {
+        // TODO: 예약 알림 발송 로직
+    }
+} 

--- a/src/main/java/com/airfryer/repicka/common/redis/RedisService.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/RedisService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -82,7 +82,7 @@ public class RedisService {
             TaskKeys keys = generateTaskKeys(queueName, taskData.getAppointmentId());
             
             // 실행 시간까지의 지연 시간 계산
-            long executeTimestamp = executeAt.toEpochSecond(ZoneOffset.UTC) * 1000;
+            long executeTimestamp = executeAt.atZone(ZoneId.systemDefault()).toEpochSecond() * 1000;
             long delayMs = executeTimestamp - System.currentTimeMillis();
             
             if (delayMs <= 0) {

--- a/src/main/java/com/airfryer/repicka/common/redis/RedisService.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/RedisService.java
@@ -124,10 +124,10 @@ public class RedisService {
     // 작업 실행 로직
     private void executeTask(AppointmentTask task) {
         switch (task.getTaskType()) {
-            case "EXPIRE":
+            case EXPIRE:
                 expireAppointment(task);
                 break;
-            case "REMIND":
+            case REMIND:
                 sendAppointmentReminder(task);
                 break;
             default:

--- a/src/main/java/com/airfryer/repicka/common/redis/dto/AppointmentTask.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/dto/AppointmentTask.java
@@ -1,20 +1,34 @@
 package com.airfryer.repicka.common.redis.dto;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import com.airfryer.repicka.domain.item.entity.TransactionType;
+import com.airfryer.repicka.domain.appointment.entity.Appointment;
+import com.airfryer.repicka.domain.appointment.entity.AppointmentType;
 
 @Getter
 @Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class AppointmentTask {
     private Long appointmentId; // 예약 아이디
-    private TransactionType transactionType; // 거래 유형
+    private AppointmentType transactionType; // 거래 유형
     private Long ownerId; // 소유자 아이디
     private Long requesterId; // 요청자 아이디
     private String taskType; // "EXPIRE", "REMIND"
+
+    public static AppointmentTask from(Appointment appointment, String taskType) {
+        return AppointmentTask.builder()
+                .appointmentId(appointment.getId())
+                .transactionType(appointment.getType())
+                .ownerId(appointment.getOwner().getId())
+                .requesterId(appointment.getRequester().getId())
+                .taskType(taskType)
+                .build();
+    }
 } 

--- a/src/main/java/com/airfryer/repicka/common/redis/dto/AppointmentTask.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/dto/AppointmentTask.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import com.airfryer.repicka.domain.appointment.entity.Appointment;
-import com.airfryer.repicka.domain.appointment.entity.AppointmentType;
 
 @Getter
 @Setter
@@ -17,17 +16,17 @@ import com.airfryer.repicka.domain.appointment.entity.AppointmentType;
 @Builder
 public class AppointmentTask {
     private Long appointmentId; // 예약 아이디
-    private AppointmentType transactionType; // 거래 유형
-    private Long ownerId; // 소유자 아이디
-    private Long requesterId; // 요청자 아이디
+    private String itemName; // 아이템 이름
+    private String ownerFcmToken; // 소유자 FCM 토큰
+    private String requesterFcmToken; // 요청자 FCM 토큰
     private String taskType; // "EXPIRE", "REMIND"
 
     public static AppointmentTask from(Appointment appointment, String taskType) {
         return AppointmentTask.builder()
                 .appointmentId(appointment.getId())
-                .transactionType(appointment.getType())
-                .ownerId(appointment.getOwner().getId())
-                .requesterId(appointment.getRequester().getId())
+                .itemName(appointment.getItem().getTitle())
+                .ownerFcmToken(appointment.getOwner().getFcmToken())
+                .requesterFcmToken(appointment.getRequester().getFcmToken())
                 .taskType(taskType)
                 .build();
     }

--- a/src/main/java/com/airfryer/repicka/common/redis/dto/AppointmentTask.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/dto/AppointmentTask.java
@@ -1,0 +1,20 @@
+package com.airfryer.repicka.common.redis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import com.airfryer.repicka.domain.item.entity.TransactionType;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppointmentTask {
+    private Long appointmentId; // 예약 아이디
+    private TransactionType transactionType; // 거래 유형
+    private Long ownerId; // 소유자 아이디
+    private Long requesterId; // 요청자 아이디
+    private String taskType; // "EXPIRE", "REMIND"
+} 

--- a/src/main/java/com/airfryer/repicka/common/redis/dto/AppointmentTask.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/dto/AppointmentTask.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import com.airfryer.repicka.common.redis.type.TaskType;
 import com.airfryer.repicka.domain.appointment.entity.Appointment;
 
 @Getter
@@ -19,9 +20,9 @@ public class AppointmentTask {
     private String itemName; // 아이템 이름
     private String ownerFcmToken; // 소유자 FCM 토큰
     private String requesterFcmToken; // 요청자 FCM 토큰
-    private String taskType; // "EXPIRE", "REMIND"
+    private TaskType taskType; // 작업 타입 (EXPIRE, REMIND)
 
-    public static AppointmentTask from(Appointment appointment, String taskType) {
+    public static AppointmentTask from(Appointment appointment, TaskType taskType) {
         return AppointmentTask.builder()
                 .appointmentId(appointment.getId())
                 .itemName(appointment.getItem().getTitle())

--- a/src/main/java/com/airfryer/repicka/common/redis/dto/KeyExpiredEvent.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/dto/KeyExpiredEvent.java
@@ -1,0 +1,15 @@
+package com.airfryer.repicka.common.redis.dto;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class KeyExpiredEvent extends ApplicationEvent {
+    
+    private final String expiredKey;
+    
+    public KeyExpiredEvent(Object source, String expiredKey) {
+        super(source);
+        this.expiredKey = expiredKey;
+    }
+}

--- a/src/main/java/com/airfryer/repicka/common/redis/type/TaskType.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/type/TaskType.java
@@ -1,0 +1,14 @@
+package com.airfryer.repicka.common.redis.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TaskType {
+    EXPIRE("EXPIRE", "예약 만료 처리"),
+    REMIND("REMIND", "예약 알림 발송");
+    
+    private final String code;
+    private final String description;
+}

--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -71,6 +71,9 @@ public class SecurityConfig
                         // Access token 재발급
                         .requestMatchers("/api/v1/refresh-token").permitAll()
 
+                        // User
+                        .requestMatchers("/api/v1/user/**").hasAnyAuthority("USER", "ADMIN")
+
                         // Appointment
                         .requestMatchers("/api/v1/appointment/**").hasAnyAuthority("USER", "ADMIN")
 

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -7,6 +7,7 @@ import com.airfryer.repicka.common.firebase.type.NotificationType;
 import com.airfryer.repicka.common.redis.RedisService;
 import com.airfryer.repicka.common.firebase.service.FCMService;
 import com.airfryer.repicka.common.redis.dto.AppointmentTask;
+import com.airfryer.repicka.common.redis.type.TaskType;
 import com.airfryer.repicka.domain.appointment.FindMyAppointmentSubject;
 import com.airfryer.repicka.domain.appointment.dto.*;
 import com.airfryer.repicka.domain.appointment.entity.Appointment;
@@ -271,7 +272,7 @@ public class AppointmentService
         // 약속 알림 발송 예약
         delayedQueueService.addDelayedTask(
                 "appointment",
-                AppointmentTask.from(appointment, "REMIND"),
+                AppointmentTask.from(appointment, TaskType.REMIND),
                 appointment.getRentalDate().minusDays(1)
         );
 
@@ -461,7 +462,7 @@ public class AppointmentService
         // 약속 알림 발송 예약
         delayedQueueService.addDelayedTask(
                 "appointment",
-                AppointmentTask.from(newAppointment, "REMIND"),
+                AppointmentTask.from(newAppointment, TaskType.REMIND),
                 newAppointment.getRentalDate().minusDays(1)
         );
 

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -4,7 +4,7 @@ import com.airfryer.repicka.common.exception.CustomException;
 import com.airfryer.repicka.common.exception.CustomExceptionCode;
 import com.airfryer.repicka.common.firebase.dto.FCMNotificationReq;
 import com.airfryer.repicka.common.firebase.type.NotificationType;
-import com.airfryer.repicka.common.redis.DelayedQueueService;
+import com.airfryer.repicka.common.redis.RedisService;
 import com.airfryer.repicka.common.firebase.service.FCMService;
 import com.airfryer.repicka.common.redis.dto.AppointmentTask;
 import com.airfryer.repicka.domain.appointment.FindMyAppointmentSubject;
@@ -35,7 +35,7 @@ public class AppointmentService
     private final AppointmentRepository appointmentRepository;
     private final ItemRepository itemRepository;
     private final ItemImageRepository itemImageRepository;
-    private final DelayedQueueService delayedQueueService;
+    private final RedisService delayedQueueService;
     private final FCMService fcmService;
 
     /// 서비스

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -306,11 +306,13 @@ public class AppointmentService
 
         appointment.cancelAppointment();
 
+        // 약속 알림 발송 예약 취소
+        delayedQueueService.cancelDelayedTask("appointment", appointmentId);
+
         // TODO: 사용자 피드백 요청
         // TODO: 채팅방 제거
 
-        /// 약속 데이터 반환
-
+        // 약속 데이터 반환
         return AppointmentRes.from(appointment, item);
     }
 

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/UpdateInProgressAppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/UpdateInProgressAppointmentService.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/src/main/java/com/airfryer/repicka/domain/user/UserController.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserController.java
@@ -1,0 +1,39 @@
+package com.airfryer.repicka.domain.user;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.airfryer.repicka.common.security.oauth2.CustomOAuth2User;
+import com.airfryer.repicka.common.response.SuccessResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PatchMapping("/fcm-token")
+    public ResponseEntity<SuccessResponseDto> updateFcmToken(@AuthenticationPrincipal CustomOAuth2User user,
+                                                             @RequestBody String fcmToken) {
+        userService.updateFcmToken(user.getUser().getId(), fcmToken);
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+                .message("푸시 알림 설정이 성공적으로 변경되었습니다.")
+                .build());
+    }
+
+    @PatchMapping("/push-enabled")
+    public ResponseEntity<SuccessResponseDto> updatePush(@AuthenticationPrincipal CustomOAuth2User user,
+                                                             @RequestBody Boolean isPushEnabled) {
+        userService.updatePush(user.getUser().getId(), isPushEnabled);
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+                .message("푸시 알림 설정이 성공적으로 변경되었습니다.")
+                .build());
+    }
+}

--- a/src/main/java/com/airfryer/repicka/domain/user/UserService.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserService.java
@@ -1,0 +1,33 @@
+package com.airfryer.repicka.domain.user;
+
+import org.springframework.stereotype.Service;
+
+import com.airfryer.repicka.common.exception.CustomException;
+import com.airfryer.repicka.common.exception.CustomExceptionCode;
+import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    // fcm 토큰 업데이트
+    public void updateFcmToken(Long userId, String fcmToken) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.USER_NOT_FOUND, null));
+        user.setFcmToken(fcmToken);
+        userRepository.save(user);
+    }
+
+    // 푸시 알림 활성화 여부 업데이트
+    public void updatePush(Long userId, Boolean isPushEnabled) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.USER_NOT_FOUND, null));
+        user.setIsPushEnabled(isPushEnabled);
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -53,6 +53,10 @@ public class User extends BaseEntity
     private Integer weight; // 몸무게
     private String fcmToken; // 푸시알림 토큰
 
+    @Builder.Default
+    @NotNull
+    private Boolean isPushEnabled = false; // 푸시알림 활성화 여부
+
     @NotNull
     private int todayPostCount; // 오늘 등록한 게시글 개수
 
@@ -76,5 +80,15 @@ public class User extends BaseEntity
     @Override
     public int hashCode() {
         return id != null ? id.hashCode() : 0;
+    }
+
+    // fcm 토큰 업데이트
+    public void setFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
+
+    // 푸시 알림 활성화 여부 업데이트
+    public void setIsPushEnabled(Boolean isPushEnabled) {
+        this.isPushEnabled = isPushEnabled;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,3 +74,8 @@ file:
 logging:
   level:
     org.springframework.security: DEBUG
+
+## Firebase 설정
+firebase:
+  config:
+    path: firebase/repicka-firebase-adminsdk.json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
   data:
     mongodb:
       uri: mongodb://${MONGODB_USERNAME}:${MONGODB_PASSWORD}@${MONGODB_URL}/${MONGODB_DATABASE}?authSource=${MONGODB_DATABASE}
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
   ## OAuth 설정
   security:


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#60 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
## Redis 대기 큐 구현
### KeyExpirationEventMessageListener
- Redis 키 만료 이벤트를 듣고 있는 역할입니다.
- 기반으로 해당 시각이 되었을 때 작업을 진행하도록 큐에서 데이터를 추출합니다.
- excuteTask 메서드에서 작업 분류에 따라 다른 기능을 수행하도록 브랜치를 나눕니다.
### METHOD addDelayedTask(queueName, taskData, executeAt)
- 지연 작업을 Redis TTL로 등록하기 위해 타 비즈니스로직에서 사용하는 메서드입니다.
- 작업 데이터와 만료 시 이벤트를 발생시키기 위한 TTL 키를 생성합니다.
- 현재는 pick에서 만료나 예약 리마인드 알림을 위한 스케줄링을 위해 AppointmentTask가 구현되어있습니다.
```
private Long appointmentId; // 예약 아이디
private String itemName; // 아이템 이름
private String ownerFcmToken; // 소유자 FCM 토큰
private String requesterFcmToken; // 요청자 FCM 토큰
private String taskType; // "EXPIRE", "REMIND"
```
<img width="764" height="258" alt="image" src="https://github.com/user-attachments/assets/09b278a9-479a-4188-805e-749f33ff34f3" />
- TTL 시간이 점점 줄어가는 모습을 볼 수 있습니다.

### METHOD cancelDelayedTask(queueName, appointmentId)
- 지연 작업을 통해 이벤트를 발생시키는 작업을 취소할 때 사용하는 메서드입니다.
- PICK이 취소되거나 확정되었을 때 레디스 큐에서 작업을 삭제하기 위해 사용합니다.
<img width="1678" height="772" alt="image" src="https://github.com/user-attachments/assets/d4d6f937-a376-43f7-93da-421e8448ffde" />
- PICK 삭제 후 사라진 모습을 볼 수 있습니다.


## FCM 푸시알림 구현
### METHOD sendNotification / sendNotificationToMultiple(token, request)
- 해당 토큰으로 푸시 알림을 보내는 작업을 수행하는 메서드입니다.
- Redis 키가 만료되었을 때 약속 리마인드 및 만료 알림, 약속 확정 알림, 채팅 알림을 위해 호출합니다.
- 푸시 알림에서 데이터 및 알림 내용으로 들어갈 내용을 FCMNotificationReq으로 전달합니다.
```
private NotificationType notificationType;
private Object relatedId;  // appointmentId(Long) 또는 chatId(ObjectId) 등
private String relatedName;  // 약속 관련 아이템 이름 또는 채팅 상대 이름
```
### ENUM NotificationType
- 각 푸시 알림에 대해 클라이언트에게 보여줄 title, body 문장을 타입에 따라 구성해두었습니다.
- 약속 리마인더 알림, 약속 확정 알림, 새로운 메시지로 구성되어있습니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
-

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
- 아키텍처 자체에서 너무 쪼개져있다거나 더 분리하면 좋을 내용이 있을까요? FCMNotificationReq에서 relatedId가 아니라 appointmentId, chatId를 따로 만들어둔다거나...

<br>