### PR TITLE
[FIX#7]: 로그인 성공 시 리다이렉트 할 경로를 클라이언트가 지정할 수 있게 변경

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.airfryer.repicka.common.security.exception.CustomAuthenticationEntryP
 import com.airfryer.repicka.common.security.jwt.JwtFilter;
 import com.airfryer.repicka.common.security.oauth2.CustomOAuth2UserService;
 import com.airfryer.repicka.common.security.oauth2.OAuth2SuccessHandler;
+import com.airfryer.repicka.common.security.redirect.CustomAuthorizationRequestResolver;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -16,6 +17,7 @@ import org.springframework.security.config.annotation.web.configurers.CsrfConfig
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -34,8 +36,11 @@ public class SecurityConfig
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
-    // JWT 필터
+    // 필터
     private final JwtFilter jwtFilter;
+
+    // 리다이렉트
+    private final ClientRegistrationRepository clientRegistrationRepository;
 
     // 예외 처리 클래스
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
@@ -51,11 +56,16 @@ public class SecurityConfig
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .headers(HeadersConfigurer::disable)
                 .sessionManagement(c -> c.sessionCreationPolicy(
-                        SessionCreationPolicy.STATELESS));
+                        SessionCreationPolicy.IF_REQUIRED));
 
         // Oauth 2.0 설정
         httpSecurity
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(config -> config
+                                .authorizationRequestResolver(
+                                        new CustomAuthorizationRequestResolver(clientRegistrationRepository)
+                                )
+                        )
                         .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
                                 .userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
@@ -106,7 +116,7 @@ public class SecurityConfig
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler));
 
-        // JWT 필터 추가
+        // 필터 추가
         httpSecurity.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
@@ -2,10 +2,11 @@ package com.airfryer.repicka.common.security.oauth2;
 
 import com.airfryer.repicka.common.security.jwt.JwtUtil;
 import com.airfryer.repicka.common.security.jwt.Token;
+import com.airfryer.repicka.common.security.redirect.CustomAuthorizationRequestResolver;
 import com.airfryer.repicka.domain.user.entity.User;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -28,11 +29,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
-                                        Authentication authentication) throws IOException, ServletException
+                                        Authentication authentication) throws IOException
     {
+        /// 계정 정보 확인
+
         // 계정 정보
         CustomOAuth2User userDetails = (CustomOAuth2User) authentication.getPrincipal();
         User user = userDetails.getUser();
+
+        /// 토큰 쿠기 생성
 
         // 토큰 생성
         String accessToken = jwtUtil.createToken(user.getId(), Token.ACCESS_TOKEN);
@@ -46,8 +51,25 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler
         response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
+        /// 리다이렉트 경로 설정
+
+        // 세션으로부터 리다이렉트 경로 추출
+        HttpSession session = request.getSession();
+        String redirectURI = (String) session.getAttribute(CustomAuthorizationRequestResolver.REDIRECT_URI_PARAMETER_NAME);
+
+        // 세션에 리다이렉트 경로가 존재하지 않는다면, 기본 경로로 리다이렉트하도록 설정
+        if(redirectURI == null || redirectURI.isBlank()) {
+            redirectURI = frontendURI;
+        }
+
+        // 세션에서 리다이렉트 경로 제거
+        session.removeAttribute(CustomAuthorizationRequestResolver.REDIRECT_URI_PARAMETER_NAME);
+
+        System.out.println("나는 성공 핸들러!!!");
+        System.out.println("redirectURI : " + redirectURI);
+
         // 리다이렉트
-        response.sendRedirect(frontendURI + "?access-token=" + accessToken + "&refresh-token=" + refreshToken);
+        response.sendRedirect(redirectURI + "?access-token=" + accessToken + "&refresh-token=" + refreshToken);
 
         // 로컬에서 WebSocket 채팅 전송 테스트 시, 리다이렉트 경로
         // response.sendRedirect("http://localhost:8080/chatTest.html" + "?access-token=" + accessToken + "&refresh-token=" + refreshToken);

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
@@ -65,9 +65,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler
         // 세션에서 리다이렉트 경로 제거
         session.removeAttribute(CustomAuthorizationRequestResolver.REDIRECT_URI_PARAMETER_NAME);
 
-        System.out.println("나는 성공 핸들러!!!");
-        System.out.println("redirectURI : " + redirectURI);
-
         // 리다이렉트
         response.sendRedirect(redirectURI + "?access-token=" + accessToken + "&refresh-token=" + refreshToken);
 

--- a/src/main/java/com/airfryer/repicka/common/security/redirect/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/airfryer/repicka/common/security/redirect/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,47 @@
+package com.airfryer.repicka.common.security.redirect;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver
+{
+    private final OAuth2AuthorizationRequestResolver defaultResolver;
+
+    public static final String REDIRECT_URI_PARAMETER_NAME = "redirectURI";
+
+    public CustomAuthorizationRequestResolver(ClientRegistrationRepository repo) {
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(repo, "/oauth2/authorization");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest req = defaultResolver.resolve(request);
+        return customizeAuthorizationRequest(request, req);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest req = defaultResolver.resolve(request, clientRegistrationId);
+        return customizeAuthorizationRequest(request, req);
+    }
+
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(HttpServletRequest request,
+                                                                     OAuth2AuthorizationRequest authRequest)
+    {
+        if(authRequest != null)
+        {
+            // 요청 파라미터로부터 리다이렉트 경로 추출
+            String redirectURI = request.getParameter(REDIRECT_URI_PARAMETER_NAME);
+
+            // 세션 등록
+            if(redirectURI != null) {
+                request.getSession().setAttribute(REDIRECT_URI_PARAMETER_NAME, redirectURI);
+            }
+        }
+
+        return authRequest;
+    }
+}


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#7 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->

<br>

**😄 로그인 성공 시 리다이렉트 할 경로를 클라이언트가 지정할 수 있게 변경하였습니다.**

<br>

Spring Security의 Oauth2 로그인 동작 흐름에 의해, 클라이언트가 로그인 요청을 보내면 백엔드 서버로 바로 오지 않습니다.
클라이언트의 요청은 Oauth2 서버로 갔다가 백엔드 서버로 리다이렉트 됩니다.

하지만 스프링 서버는 일단 기본적으로 stateless하게 동작합니다.
허나, 로그인 요청은 다른 서버를 거쳐서 오기 때문에 세션을 사용하지 않으면 redirectURI 요청 파라미터를 기억하지 못합니다.
그렇기 때문에, 불가피하게 세션으로 구현하였습니다.

<br>

**세션 저장**

`CustomAuthorizationRequestResolver`의 `customizeAuthorizationRequest` 메서드가 redirectURI을 기억할 수 있도록 세션을 저장하는 역할을 수행합니다.
해당 클래스는 `OAuth2AuthorizationRequestResolver` 인터페이스를 구현합니다.
이를 `SecurityConfig`에 등록하여 클라이언트가 인증 요청을 할 때 해당 요청에 대한 추가적인 작업을 수행하는 것입니다.

<br>

**세션 사용**

위의 과정으로 저장한 세션은 `OAuth2SuccessHandler`에서 사용합니다!
HTTP 요청으로부터 세션을 추출하고, 해당 세션으로부터 리다이렉트 경로를 추출하는 것이지요.

<br>

**결과**

📄 **로그인 경로** : /oauth2/authorization/google

- 파라미터로 아무 것도 넣지 않으면 기본 경로(https://repicka.netlify.app/)로 리다이렉트

<br>

📄 **로그인 경로** : /oauth2/authorization/google?redirectURI=https://example.com
- 파라미터로 **`redirectURI`** 를 넣으면 해당 경로로 리다이렉트

<br>


테스트 결과, 구글 및 카카오 전부 잘 되는 것을 확인하였습니다!

</aside>

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->

실제 배포를 하게 된다면 다음 2가지를 조치해야 됨!
- 리다이렉트 경로를 커스터마이징하지 못하도록 롤백
- accessToken 및 refreshToken을 쿠키로만 반환하도록 변경

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>