### PR TITLE
[FEAT#52]: 채팅 불러오기 API 구현

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/firebase/dto/FCMNotificationReq.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/dto/FCMNotificationReq.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class FCMNotificationReq {
     private NotificationType notificationType;
-    private Object relatedId;  // appointmentId(Long) 또는 chatId(ObjectId) 등
+    private String relatedId;  // appointmentId, chatId 등
     private String relatedName;  // 약속 관련 아이템 이름 또는 채팅 상대 이름
     
     // 제목 생성
@@ -26,7 +26,7 @@ public class FCMNotificationReq {
         return notificationType.getFormattedBody(relatedName);
     }
 
-    public static FCMNotificationReq of(NotificationType notificationType, Object id, String name) {
+    public static FCMNotificationReq of(NotificationType notificationType, String id, String name) {
         return FCMNotificationReq.builder()
             .notificationType(notificationType)
             .relatedId(id)

--- a/src/main/java/com/airfryer/repicka/common/firebase/service/FCMService.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/service/FCMService.java
@@ -30,7 +30,7 @@ public class FCMService {
                             .setBody(request.getBody())
                             .build())
                     .putData("notificationType", request.getNotificationType().name())
-                    .putData("relatedId", request.getRelatedId().toString())
+                    .putData("relatedId", request.getRelatedId())
                     .build();
 
             firebaseMessaging.send(message);
@@ -59,7 +59,7 @@ public class FCMService {
                             .setBody(request.getBody())
                             .build())
                     .putData("notificationType", request.getNotificationType().name())
-                    .putData("relatedId", request.getRelatedId().toString())
+                    .putData("relatedId", request.getRelatedId())
                     .build();
 
             firebaseMessaging.sendEachForMulticast(message);

--- a/src/main/java/com/airfryer/repicka/common/redis/RedisService.java
+++ b/src/main/java/com/airfryer/repicka/common/redis/RedisService.java
@@ -144,7 +144,7 @@ public class RedisService {
     
     // 예약 알림 발송
     private void sendAppointmentReminder(AppointmentTask task) {
-        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_REMINDER, task.getAppointmentId(), task.getItemName());
+        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_REMINDER, task.getAppointmentId().toString(), task.getItemName());
         fcmService.sendNotificationToMultiple(List.of(task.getOwnerFcmToken(), task.getRequesterFcmToken()), notificationReq);
     }
 } 

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -266,7 +266,7 @@ public class AppointmentService
         appointment.confirmAppointment();
 
         // 약속 확정 알림
-        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_CONFIRMATION, appointment.getId(), appointment.getItem().getTitle());
+        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_CONFIRMATION, appointment.getId().toString(), appointment.getItem().getTitle());
         fcmService.sendNotification(appointment.getCreator().getFcmToken(), notificationReq);
 
         // 약속 알림 발송 예약
@@ -357,15 +357,14 @@ public class AppointmentService
 
         /// 대표 이미지 리스트 조회
 
-        List<ItemImage> thumbnailList = itemImageRepository.findThumbnailListByItemIdList(appointmentPage.stream().map(appointment -> {
-            return appointment.getItem().getId();
-        }).toList());
+        // 대표 이미지 리스트 조회
+        List<ItemImage> thumbnailList = itemImageRepository.findThumbnailListByItemIdList(appointmentPage.stream().map(appointment -> appointment.getItem().getId()).toList());
 
         // Map(제품 ID, 대표 이미지 URL) 생성
         Map<Long, String> thumbnailUrlMap = thumbnailList.stream()
                 .collect(Collectors.toMap(
                         itemImage -> itemImage.getItem().getId(),
-                        itemImage -> itemImage.getFileKey()
+                        ItemImage::getFileKey
                 ));
 
         // Map(약속, 대표 이미지 URL) 생성
@@ -456,7 +455,7 @@ public class AppointmentService
         appointmentRepository.save(newAppointment);
 
         // 약속 확정 알림
-        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_CONFIRMATION, newAppointment.getId(), newAppointment.getItem().getTitle());
+        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_CONFIRMATION, newAppointment.getId().toString(), newAppointment.getItem().getTitle());
         fcmService.sendNotification(newAppointment.getCreator().getFcmToken(), notificationReq);
 
         // 약속 알림 발송 예약

--- a/src/main/java/com/airfryer/repicka/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.airfryer.repicka.domain.chat.controller;
 
 import com.airfryer.repicka.common.response.SuccessResponseDto;
 import com.airfryer.repicka.common.security.oauth2.CustomOAuth2User;
+import com.airfryer.repicka.domain.chat.dto.ChatPageDto;
 import com.airfryer.repicka.domain.chat.dto.EnterChatRoomRes;
 import com.airfryer.repicka.domain.chat.dto.SendChatDto;
 import com.airfryer.repicka.domain.chat.service.ChatService;
@@ -48,5 +49,22 @@ public class ChatController
         CustomOAuth2User oAuth2User = (CustomOAuth2User) ((Authentication) principal).getPrincipal();
         User user = oAuth2User.getUser();
         chatService.sendMessage(user, dto);
+    }
+
+    // 채팅 불러오기
+    @GetMapping("/chatroom/{chatRoomId}/load-chat")
+    public ResponseEntity<SuccessResponseDto> loadChat(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+                                                       @PathVariable Long chatRoomId,
+                                                       @RequestParam int pageSize,
+                                                       @RequestParam String cursorId)
+    {
+        User user = oAuth2User.getUser();
+        ChatPageDto data = chatService.loadChat(user, chatRoomId, pageSize, cursorId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("채팅을 성공적으로 불러왔습니다.")
+                        .data(data)
+                        .build());
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/dto/ChatMessageDto.java
@@ -3,24 +3,27 @@ package com.airfryer.repicka.domain.chat.dto;
 import com.airfryer.repicka.domain.chat.entity.Chat;
 import lombok.Builder;
 import lombok.Getter;
-import org.bson.types.ObjectId;
+
+import java.util.Date;
 
 @Getter
 @Builder
 public class ChatMessageDto
 {
-    private ObjectId chatId;    // 채팅 ID
+    private String chatId;      // 채팅 ID
     private Long userId;        // 사용자 ID
     private String content;     // 내용
     private Boolean isPick;     // PICK 여부
+    private Date createdAt;     // 채팅 생성 날짜
 
     public static ChatMessageDto from(Chat chat)
     {
         return ChatMessageDto.builder()
-                .chatId(chat.getId())
+                .chatId(chat.getId().toHexString())
                 .userId(chat.getUserId())
                 .content(chat.getContent())
                 .isPick(chat.getIsPick())
+                .createdAt(chat.getId().getDate())
                 .build();
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/dto/ChatPageDto.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/dto/ChatPageDto.java
@@ -3,7 +3,6 @@ package com.airfryer.repicka.domain.chat.dto;
 import com.airfryer.repicka.domain.chat.entity.Chat;
 import lombok.Builder;
 import lombok.Getter;
-import org.bson.types.ObjectId;
 
 import java.util.List;
 
@@ -12,10 +11,10 @@ import java.util.List;
 public class ChatPageDto
 {
     private List<ChatMessageDto> messages;  // 채팅 리스트
-    private ObjectId cursorId;              // 채팅: 커서 ID
+    private String cursorId;                // 채팅: 커서 ID
     private Boolean hasNext;                // 채팅: 다음 페이지가 존재하는가?
 
-    public static ChatPageDto of(List<Chat> chatList, ObjectId cursorId, boolean hasNext)
+    public static ChatPageDto of(List<Chat> chatList, String cursorId, boolean hasNext)
     {
         return ChatPageDto.builder()
                 .messages(chatList.stream().map(ChatMessageDto::from).toList())

--- a/src/main/java/com/airfryer/repicka/domain/chat/dto/EnterChatRoomRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/dto/EnterChatRoomRes.java
@@ -7,7 +7,6 @@ import com.airfryer.repicka.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import org.bson.types.ObjectId;
 
 import java.util.List;
 
@@ -23,9 +22,8 @@ public class EnterChatRoomRes
                                       User me,
                                       String imageUrl,
                                       List<Chat> chatList,
-                                      ObjectId chatCursorId,
-                                      boolean chatHasNext,
-                                      boolean isAvailable)
+                                      String chatCursorId,
+                                      boolean chatHasNext)
     {
         return EnterChatRoomRes.builder()
                 .chatRoom(ChatRoomDto.from(chatRoom, me))

--- a/src/main/java/com/airfryer/repicka/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/repository/ChatRepository.java
@@ -4,7 +4,6 @@ import com.airfryer.repicka.domain.chat.entity.Chat;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 
 import java.util.List;
 
@@ -12,9 +11,9 @@ public interface ChatRepository extends MongoRepository<Chat, ObjectId>
 {
     /// 채팅방 ID로 채팅 리스트 조회
 
-    // 커서 기반 페이지네이션 (cursor: id)
+    // 커서 기반 페이지네이션 (cursor: 채팅 ID)
     // 최신순 정렬
-    List<Chat> findByChatRoomIdAndIdLessThanOrderByIdDesc(Long chatRoomId, ObjectId id, Pageable pageable);
+    List<Chat> findByChatRoomIdAndIdLessThanEqualOrderByIdDesc(Long chatRoomId, ObjectId id, Pageable pageable);
 
     // 첫 페이지 조회
     List<Chat> findByChatRoomIdOrderByIdDesc(Long chatRoomId, Pageable pageable);


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->

#52 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->

### 1. MongoDB의 Document ID의 비밀

<br>

**😎 밑에 한줄요약 있음!!!!!!!!!!**

<br>

<img width="306" height="135" alt="image" src="https://github.com/user-attachments/assets/48f00541-6253-4ba3-9d4b-75fc943d9217" />

<br>

MongoDB Compass를 통해 Document의 `id`를 조회해보면 위와 같은 모습입니다.

<br>

```json
{
    "timestamp": 1752568308,
    "date": "2025-07-15T08:31:48.000+00:00"
}
```

그런데 이상하게 스프링에서 MongoDB Document를 조회한 뒤, 클라이언트에게 해당 Document의 `id`를 그대로 전달하면 위와 같은 형태로 전달됩니다.

지금까지는 그냥 그런갑다 하고 넘어갔었습니다..
**그런데 채팅 불러오기의 커서 페이지네이션을 위해 클라이언트가 요청 파라미터로 채팅 ID를 넘겨야 할 필요성이 생겼습니다.**
하지만 json 데이터를 파라미터로 넘길 순 없죠..
MongoDB Compass에서 보이는 것처럼 `id`를 문자열 형식으로 넘겨줘야 했습니다.

즉, 스프링에서도 Compass처럼 `id` 데이터를 문자열로 다룰 방법을 알아야 했습니다!
이를 위해 자료를 찾아보니 두 툴에서 `id`가 서로 다른 형식이었던 이유를 찾았습니다.

**그 이유는 Spring Data MongoDB가 단순 문자열 형식의 `id`를 ObjectId 형식으로 변환했기 때문입니다!**
그렇기에 스프링에서는 문자열 형태가 아닌 `ObjectId` 형태로 `id`를 다뤘고, `ObjectId` 형태로 클라이언트에게 응답했기 때문에, 클라이언트는 문자열이 아닌 JSON 형태의 `id`를 받았던 것이지요.

이유를 알았으니 `ObjectId` 형태를 다시 `String`으로 변환할 방법이 필요했습니다.
이는 생각보다 간단했습니다.

```java
ObjectId id = {MongoDB로부터 가져온 Document id};
String parsedId = id.toHexString();
```

그냥 16진수 문자열로 변환해주기만 하면 MongoDB Compass에서 볼 수 있는 `id`와 완전히 동일한 문자열 형태의 `id`를 확인할 수 있었습니다~

<br>

**😎 한줄요약 : 클라이언트가 채팅 ID가 필요한 일이 있으면, MongoDB로부터 Document의 id를 가져와서 바로 응답하지 말고 16진수 문자열로 변환해서 응답해라!**

<br>

### 2. 채팅 불러오기 API 구현

<br>

채팅을 불러오는 API를 구현했습니다.
**요청 경로** : [GET] /api/v1/chatroom/{chatRoomId}/load-chat
- **PathVariable**
    - **chatRoomId** : 채팅방 ID
- **RequestParam**
    - **pageSize** : 결과로 받을 채팅 개수
    - **cursorId** : 커서 데이터 (채팅방 ID)

<br>

**응답**

```json
{
    "message": "채팅을 성공적으로 불러왔습니다.",
    "data": {
        "messages": [
            {
                "chatId": "687611f41f1ef08498ae5d4b",
                "userId": 1,
                "content": "이것은 채팅이다.",
                "isPick": false,
                "createdAt": "2025-07-15T08:31:48.000+00:00"
            },
            ...
        ],
        "cursorId": "687611f41f1ef08498ae5d46",
        "hasNext": true
    }
}
```

- 응답으로 오는 `messages` 는 생성 날짜의 내림차순 기준으로 정렬됩니다.
- 응답으로 오는 커서 데이터는 다음 페이지가 필요할 때 요청에 추가하면 됩니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- 채팅 읽음 처리 및 채팅방 읽지 않은 채팅 개수 구현

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>