### PR TITLE
[FEAT#74]: 유저 프로필 정보 수정

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/CustomOAuth2UserService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.Optional;
-import java.util.UUID;
+import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
@@ -46,9 +46,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         // 이미 존재하는 사용자가 아니라면 새로 추가
         if(existUser.isEmpty()) {
+            // 랜덤 4자리 숫자 생성
+            Random random = new Random();
+            int randomNumber = random.nextInt(9000) + 1000; // 1000~9999 범위의 4자리 숫자
+            
             user = User.builder()
                     .email(oAuth2Response.getEmail())
-                    .nickname("호랑이" + UUID.randomUUID())
+                    .nickname("호랑이" + randomNumber)
                     .loginMethod(oAuth2Response.getProvider())
                     .oauthId(oAuth2Response.getProviderId())
                     .role(Role.USER)

--- a/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/airfryer/repicka/common/security/oauth2/OAuth2SuccessHandler.java
@@ -37,7 +37,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler
         CustomOAuth2User userDetails = (CustomOAuth2User) authentication.getPrincipal();
         User user = userDetails.getUser();
 
-        /// 토큰 쿠기 생성
+        /// 토큰 쿠키 생성
 
         // 토큰 생성
         String accessToken = jwtUtil.createToken(user.getId(), Token.ACCESS_TOKEN);

--- a/src/main/java/com/airfryer/repicka/domain/item/ItemController.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/ItemController.java
@@ -36,7 +36,7 @@ public class ItemController
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponseDto.builder()
-                        .message("Presigned URL을 성공적으로 생성하였습니다.")
+                        .message("제품 이미지 업로드용 Presigned URL을 성공적으로 생성하였습니다.")
                         .data(presignedUrlRes)
                         .build());
     }

--- a/src/main/java/com/airfryer/repicka/domain/user/UserController.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserController.java
@@ -58,6 +58,16 @@ public class UserController {
             .build());
     }
 
+    // 프로필 조회
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto> getProfile(@AuthenticationPrincipal CustomOAuth2User user) {
+        BaseUserDto userDetail = userService.getProfile(user.getUser().getId());
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+            .message("프로필을 성공적으로 조회하였습니다.")
+            .data(userDetail)
+            .build());
+    }
+
     // 프로필 업데이트
     @PutMapping
     public ResponseEntity<SuccessResponseDto> updateProfile(@AuthenticationPrincipal CustomOAuth2User user,

--- a/src/main/java/com/airfryer/repicka/domain/user/UserController.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserController.java
@@ -2,13 +2,19 @@ package com.airfryer.repicka.domain.user;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.airfryer.repicka.common.security.oauth2.CustomOAuth2User;
+
+import jakarta.validation.Valid;
+
 import com.airfryer.repicka.common.response.SuccessResponseDto;
+import com.airfryer.repicka.common.aws.s3.dto.PresignedUrlReq;
+import com.airfryer.repicka.common.aws.s3.dto.PresignedUrlRes;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,8 +30,8 @@ public class UserController {
                                                              @RequestBody String fcmToken) {
         userService.updateFcmToken(user.getUser().getId(), fcmToken);
         return ResponseEntity.ok(SuccessResponseDto.builder()
-                .message("푸시 알림 설정이 성공적으로 변경되었습니다.")
-                .build());
+            .message("푸시 알림 설정이 성공적으로 변경되었습니다.")
+            .build());
     }
 
     @PatchMapping("/push-enabled")
@@ -33,7 +39,17 @@ public class UserController {
                                                              @RequestBody Boolean isPushEnabled) {
         userService.updatePush(user.getUser().getId(), isPushEnabled);
         return ResponseEntity.ok(SuccessResponseDto.builder()
-                .message("푸시 알림 설정이 성공적으로 변경되었습니다.")
-                .build());
+            .message("푸시 알림 설정이 성공적으로 변경되었습니다.")
+            .build());
+    }
+
+    // S3 Presigned URL 조회
+    @GetMapping("/presigned-url")
+    public ResponseEntity<SuccessResponseDto> getPresignedUrl(@Valid PresignedUrlReq req) {
+        PresignedUrlRes presignedUrlRes = userService.getPresignedUrl(req);
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+            .message("프로필 이미지 업로드 준비가 완료되었습니다.")
+            .data(presignedUrlRes)
+            .build());
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/UserController.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserController.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,6 +16,8 @@ import jakarta.validation.Valid;
 import com.airfryer.repicka.common.response.SuccessResponseDto;
 import com.airfryer.repicka.common.aws.s3.dto.PresignedUrlReq;
 import com.airfryer.repicka.common.aws.s3.dto.PresignedUrlRes;
+import com.airfryer.repicka.domain.user.dto.BaseUserDto;
+import com.airfryer.repicka.domain.user.dto.UpdateUserReq;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +28,7 @@ public class UserController {
 
     private final UserService userService;
 
+    // fcm 토큰 업데이트
     @PatchMapping("/fcm-token")
     public ResponseEntity<SuccessResponseDto> updateFcmToken(@AuthenticationPrincipal CustomOAuth2User user,
                                                              @RequestBody String fcmToken) {
@@ -34,6 +38,7 @@ public class UserController {
             .build());
     }
 
+    // 푸시 알림 설정 업데이트
     @PatchMapping("/push-enabled")
     public ResponseEntity<SuccessResponseDto> updatePush(@AuthenticationPrincipal CustomOAuth2User user,
                                                              @RequestBody Boolean isPushEnabled) {
@@ -50,6 +55,17 @@ public class UserController {
         return ResponseEntity.ok(SuccessResponseDto.builder()
             .message("프로필 이미지 업로드 준비가 완료되었습니다.")
             .data(presignedUrlRes)
+            .build());
+    }
+
+    // 프로필 업데이트
+    @PutMapping
+    public ResponseEntity<SuccessResponseDto> updateProfile(@AuthenticationPrincipal CustomOAuth2User user,
+                                                             @Valid @RequestBody UpdateUserReq req) {
+        BaseUserDto userDetail = userService.updateProfile(user.getUser().getId(), req);
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+            .message("프로필을 성공적으로 수정하였습니다.")
+            .data(userDetail)
             .build());
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/UserService.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserService.java
@@ -8,6 +8,8 @@ import com.airfryer.repicka.common.aws.s3.S3Service;
 import com.airfryer.repicka.common.aws.s3.dto.PresignedUrlReq;
 import com.airfryer.repicka.common.aws.s3.dto.PresignedUrlRes;
 import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.domain.user.dto.BaseUserDto;
+import com.airfryer.repicka.domain.user.dto.UpdateUserReq;
 import com.airfryer.repicka.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -38,5 +40,15 @@ public class UserService {
     // S3 Presigned URL 조회
     public PresignedUrlRes getPresignedUrl(PresignedUrlReq req) {
         return s3Service.generatePresignedUrl(req, "profile");
+    }
+
+    // 프로필 업데이트
+    public BaseUserDto updateProfile(Long userId, UpdateUserReq req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.USER_NOT_FOUND, null));
+        user.updateProfile(req);
+        userRepository.save(user);
+
+        return BaseUserDto.from(user);
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/UserService.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserService.java
@@ -42,6 +42,13 @@ public class UserService {
         return s3Service.generatePresignedUrl(req, "profile");
     }
 
+    // 프로필 조회
+    public BaseUserDto getProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.USER_NOT_FOUND, null));
+        return BaseUserDto.from(user);
+    }
+
     // 프로필 업데이트
     public BaseUserDto updateProfile(Long userId, UpdateUserReq req) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/airfryer/repicka/domain/user/UserService.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserService.java
@@ -4,6 +4,9 @@ import org.springframework.stereotype.Service;
 
 import com.airfryer.repicka.common.exception.CustomException;
 import com.airfryer.repicka.common.exception.CustomExceptionCode;
+import com.airfryer.repicka.common.aws.s3.S3Service;
+import com.airfryer.repicka.common.aws.s3.dto.PresignedUrlReq;
+import com.airfryer.repicka.common.aws.s3.dto.PresignedUrlRes;
 import com.airfryer.repicka.domain.user.entity.User;
 import com.airfryer.repicka.domain.user.repository.UserRepository;
 
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3Service s3Service;
 
     // fcm 토큰 업데이트
     public void updateFcmToken(Long userId, String fcmToken) {
@@ -29,5 +33,10 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(CustomExceptionCode.USER_NOT_FOUND, null));
         user.setIsPushEnabled(isPushEnabled);
         userRepository.save(user);
+    }
+
+    // S3 Presigned URL 조회
+    public PresignedUrlRes getPresignedUrl(PresignedUrlReq req) {
+        return s3Service.generatePresignedUrl(req, "profile");
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/dto/BaseUserDto.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/dto/BaseUserDto.java
@@ -1,6 +1,8 @@
 package com.airfryer.repicka.domain.user.dto;
 
 import com.airfryer.repicka.domain.user.entity.User;
+import com.airfryer.repicka.domain.user.entity.Gender;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,6 +15,10 @@ public class BaseUserDto
     private String profileImageUrl;         // 프로필 사진
     private Boolean isKoreanUnivVerified;   // 고려대 학생 인증 여부
 
+    private Gender gender;                // 성별
+    private Integer height;                // 키
+    private Integer weight;                // 몸무게
+
     public static BaseUserDto from(User user)
     {
         return BaseUserDto.builder()
@@ -20,6 +26,9 @@ public class BaseUserDto
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
                 .isKoreanUnivVerified(user.getIsKoreaUnivVerified())
+                .gender(user.getGender())
+                .height(user.getHeight())
+                .weight(user.getWeight())
                 .build();
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/dto/UpdateUserReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/dto/UpdateUserReq.java
@@ -1,0 +1,28 @@
+package com.airfryer.repicka.domain.user.dto;
+
+import com.airfryer.repicka.domain.user.entity.Gender;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateUserReq {
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하이어야 합니다.")
+    private String nickname;    // 닉네임
+
+    private String profileImageUrl;    // 프로필 이미지
+
+    private Gender gender;    // 성별
+
+    @Min(value = 100, message = "키는 100cm 이상이어야 합니다.")
+    @Max(value = 250, message = "키는 250cm 이하이어야 합니다.")
+    private Integer height;    // 키
+
+    @Min(value = 30, message = "몸무게는 30kg 이상이어야 합니다.")
+    @Max(value = 200, message = "몸무게는 200kg 이하이어야 합니다.")
+    private Integer weight;    // 몸무게
+}

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.airfryer.repicka.domain.user.entity;
 
 import com.airfryer.repicka.common.entity.BaseEntity;
+import com.airfryer.repicka.domain.user.dto.UpdateUserReq;
+
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -90,5 +92,14 @@ public class User extends BaseEntity
     // 푸시 알림 활성화 여부 업데이트
     public void setIsPushEnabled(Boolean isPushEnabled) {
         this.isPushEnabled = isPushEnabled;
+    }
+
+    // 프로필 업데이트
+    public void updateProfile(UpdateUserReq profileDetail) {
+        this.nickname = profileDetail.getNickname();
+        this.profileImageUrl = profileDetail.getProfileImageUrl();
+        this.gender = profileDetail.getGender();
+        this.height = profileDetail.getHeight();
+        this.weight = profileDetail.getWeight();
     }
 }


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#74 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->

### Profile presigned-url 조회
**GET /api/v1/user/presigned-url**
사용자 프로필 이미지 업로드를 위한 presigned URL 조회 기능을 구현하였습니다.
- UserController.java: 프로필 presigned URL 조회 API 엔드포인트 추가
- UserService.java: S3 presigned URL 생성 로직 구현
### 유저 정보 수정 구현
**PUT /api/v1/user**
사용자 프로필 정보 수정 기능을 구현하였습니다
- UpdateUserReq.java: nickname, profileImageUrl, gender, height, weight 정보
  - nickname 2~10자, height 100~250cm, weight 30~200kg 제한 설정
  - 닉네임 제외 선택 옵션으로 입력하지 않을 경우 null로 초기화됩니다
- BaseUserDto.java: 기본 유저 정보 DTO 클래스에 gender, height, weight 추가

### 유저 프로필 조회 API 구현 
**GET /api/v1/user**
사용자 프로필 정보 조회 기능을 구현하였습니다.
BaseUserDto를 반환하며 프로필 수정 시 반환되는 데이터와 동일합니다.

### 처음 유저 회원가입 시 랜덤 닉네임 변경
OAuth2 회원가입 시 닉네임을 "호랑이" + 랜덤 4자리 숫자로 생성하도록 변경하였습니다.



<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
-

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>