### PR TITLE
[FEAT#52]: 채팅방 생성 API 구현

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/configuration/websocket/WebSocketAccessInterceptor.java
+++ b/src/main/java/com/airfryer/repicka/common/configuration/websocket/WebSocketAccessInterceptor.java
@@ -129,7 +129,7 @@ public class WebSocketAccessInterceptor implements ChannelInterceptor
                 .orElseThrow(() -> new CustomException(CustomExceptionCode.CHATROOM_NOT_FOUND, chatRoomId));
 
         // 채팅방 참가자인지 확인
-        if(!chatRoom.getRequester().getId().equals(userId) && !chatRoom.getOwner().getId().equals(userId)) {
+        if(!Objects.equals(userId, chatRoom.getRequester().getId()) && !Objects.equals(userId, chatRoom.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.NOT_CHATROOM_PARTICIPANT, null);
         }
 

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -78,7 +78,7 @@ public class AppointmentService
         }
 
         // 요청자와 제품 소유자가 다른 사용자인지 체크
-        if(item.getOwner().equals(requester)) {
+        if(Objects.equals(requester.getId(), item.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.SAME_OWNER_AND_REQUESTER, null);
         }
 

--- a/src/main/java/com/airfryer/repicka/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/controller/ChatController.java
@@ -19,7 +19,20 @@ public class ChatController
 {
     private final ChatService chatService;
 
-    // TODO: 채팅방 생성
+    // 채팅방 생성
+    @PostMapping("/chatroom")
+    public ResponseEntity<SuccessResponseDto> createChatRoom(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+                                                             @RequestBody @Valid CreateChatRoomReq createChatRoomReq)
+    {
+        User user = oAuth2User.getUser();
+        EnterChatRoomRes data = chatService.createChatRoom(user, createChatRoomReq.getItemId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("채팅방을 성공적으로 생성하였습니다.")
+                        .data(data)
+                        .build());
+    }
 
     // 채팅방 ID로 채팅방에 입장할 때 필요한 데이터를 조회
     @GetMapping("/chatroom/{chatRoomId}/enter")

--- a/src/main/java/com/airfryer/repicka/domain/chat/dto/CreateChatRoomReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/dto/CreateChatRoomReq.java
@@ -1,0 +1,11 @@
+package com.airfryer.repicka.domain.chat.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CreateChatRoomReq
+{
+    @NotNull
+    private Long itemId;
+}

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -46,6 +46,32 @@ public class ChatService
 
     /// 서비스
 
+    // 채팅방 생성
+    @Transactional
+    public EnterChatRoomRes createChatRoom(User requester, Long itemId)
+    {
+        /// 제품 조회
+
+        // 제품 조회
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.ITEM_NOT_FOUND, itemId));
+
+        // 이미 삭제된 제품인 경우, 예외 처리
+        if(item.getIsDeleted()) {
+            throw new CustomException(CustomExceptionCode.ALREADY_DELETED_ITEM, null);
+        }
+
+        /// 채팅방 조회 (존재하지 않으면 생성)
+
+        ChatRoom chatRoom = createChatRoom(item, requester);
+
+        // TODO: PICK 메시지 전송
+
+        /// 채팅방 입장 데이터 반환
+
+        return enterChatRoom(requester, chatRoom, 1);
+    }
+
     // 채팅방 ID로 채팅방에 입장할 때 필요한 데이터를 조회
     @Transactional
     public EnterChatRoomRes enterChatRoom(User user, Long chatRoomId, int pageSize)

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -65,7 +65,7 @@ public class ChatService
         /// 예외 처리
 
         // 채팅방 관계자인지 확인
-        if(!chatRoom.getRequester().equals(user) && !chatRoom.getOwner().equals(user)) {
+        if(!Objects.equals(user.getId(), chatRoom.getRequester().getId()) && !Objects.equals(user.getId(), chatRoom.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.NOT_CHATROOM_PARTICIPANT, null);
         }
 
@@ -168,7 +168,7 @@ public class ChatService
                 .orElseThrow(() -> new CustomException(CustomExceptionCode.ITEM_NOT_FOUND, itemId));
 
         // 제품 소유자가 아닌 경우, 예외 처리
-        if(!item.getOwner().equals(user)) {
+        if(!Objects.equals(user.getId(), item.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.NOT_ITEM_OWNER, null);
         }
 
@@ -205,7 +205,7 @@ public class ChatService
         /// 예외 처리
 
         // 채팅방 관계자인지 확인
-        if(!chatRoom.getRequester().equals(user) && !chatRoom.getOwner().equals(user)) {
+        if(!Objects.equals(user.getId(), chatRoom.getRequester().getId()) && !Objects.equals(user.getId(), chatRoom.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.NOT_CHATROOM_PARTICIPANT, null);
         }
 
@@ -297,7 +297,7 @@ public class ChatService
         /// 예외 처리
 
         // 요청자와 제품 소유자가 다른 사용자인지 체크
-        if(requester.equals(item.getOwner())) {
+        if(Objects.equals(requester.getId(), item.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.SAME_OWNER_AND_REQUESTER, null);
         }
 

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -362,6 +362,10 @@ public class ChatService
                     .participant(item.getOwner())
                     .build());
 
+            /// 제품의 채팅방 개수 증가
+
+            item.addChatRoomCount();
+
             return chatRoom;
         }
     }

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatWebSocketService.java
@@ -55,7 +55,7 @@ public class ChatWebSocketService
         }
 
         // 채팅방 관계자인지 확인
-        if(!chatRoom.getRequester().equals(user) && !chatRoom.getOwner().equals(user)) {
+        if(!Objects.equals(user.getId(), chatRoom.getRequester().getId()) && !Objects.equals(user.getId(), chatRoom.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.NOT_CHATROOM_PARTICIPANT, null);
         }
 

--- a/src/main/java/com/airfryer/repicka/domain/item/ItemService.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/ItemService.java
@@ -380,7 +380,7 @@ public class ItemService
         }
 
         // 요청자와 제품 소유자가 다른 사용자인지 체크
-        if(item.getOwner().equals(requester)) {
+        if(Objects.equals(requester.getId(), item.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.SAME_OWNER_AND_REQUESTER, null);
         }
 
@@ -416,7 +416,7 @@ public class ItemService
             .orElseThrow(() -> new CustomException(CustomExceptionCode.ITEM_NOT_FOUND, itemId));
 
         // 권한 확인
-        if (!item.getOwner().getId().equals(user.getId())) {
+        if(!Objects.equals(user.getId(), item.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.ITEM_ACCESS_FORBIDDEN, null);
         }
 

--- a/src/main/java/com/airfryer/repicka/domain/item/dto/res/ItemDetailRes.java
+++ b/src/main/java/com/airfryer/repicka/domain/item/dto/res/ItemDetailRes.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Builder
@@ -20,7 +21,7 @@ public class ItemDetailRes
 
     public static ItemDetailRes from(Item item, List<String> imageUrls, User currentUser, boolean isLiked)
     {
-        boolean isMine = (currentUser != null) && (currentUser.getId().equals(item.getOwner().getId()));
+        boolean isMine = (currentUser != null) && (Objects.equals(currentUser.getId(), item.getOwner().getId()));
 
         return ItemDetailRes.builder()
                 .itemId(item.getId())

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -66,18 +66,4 @@ public class User extends BaseEntity
 
     @NotNull
     private LocalDate lastAccessDate; // 마지막 접속 날짜
-
-    /// 객체 비교
-
-    public boolean equals(User user)
-    {
-        return id.equals(user.getId());
-    }
-
-    /// 해시 코드
-
-    @Override
-    public int hashCode() {
-        return id != null ? id.hashCode() : 0;
-    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/User.java
@@ -51,8 +51,12 @@ public class User extends BaseEntity
 
     private Integer height; // 키
     private Integer weight; // 몸무게
+    // fcm 토큰 업데이트
+    @Setter
     private String fcmToken; // 푸시알림 토큰
 
+    // 푸시 알림 활성화 여부 업데이트
+    @Setter
     @Builder.Default
     @NotNull
     private Boolean isPushEnabled = false; // 푸시알림 활성화 여부
@@ -65,14 +69,9 @@ public class User extends BaseEntity
 
     /// 객체 비교
 
-    @Override
-    public boolean equals(Object o)
+    public boolean equals(User user)
     {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        User user = (User) o;
-        return id != null && id.equals(user.getId());
+        return id.equals(user.getId());
     }
 
     /// 해시 코드
@@ -80,15 +79,5 @@ public class User extends BaseEntity
     @Override
     public int hashCode() {
         return id != null ? id.hashCode() : 0;
-    }
-
-    // fcm 토큰 업데이트
-    public void setFcmToken(String fcmToken) {
-        this.fcmToken = fcmToken;
-    }
-
-    // 푸시 알림 활성화 여부 업데이트
-    public void setIsPushEnabled(Boolean isPushEnabled) {
-        this.isPushEnabled = isPushEnabled;
     }
 }


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#52 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->

### 1. 채팅방 생성 API 구현

<br/>

**요청 경로** : [POST] /api/v1/chatroom

- 채팅방을 새로 생성한 뒤, 입장 시점에 필요한 데이터를 반환합니다.
- 채팅방이 이미 존재하는 경우, 실제로 생성하는 대신 기존의 채팅방 데이터를 반환합니다.

<br/>

### 2. User 객체의 `equals` 및 `hashCode` 메서드 삭제

<br/>

User 객체끼리의 비교 로직을 통일하기 위해 `equals` 및 `hashCode` 메서드를 구현했었습니다.
그러나, 스프링에서 사용자 데이터를 DB에서 FK로써 가져오는 경우에는 User 객체가 아닌 프록시 객체로 가져오기 때문에, 예기치 못한 동작을 하는 것을 확인하였습니다.
이에, 해당 메서드들을 제거하였습니다.

<br/>

### 3. User 객체의 `setFcmToken` 및 `setIsPushEnabled` 메서드를 `@Setter`로 단순화

<br/>

말 그대로 입니다.
User 객체의 `setFcmToken` 및 `setIsPushEnabled` 메서드를 `@Setter`로 단순화하였습니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- 

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>