### PR TITLE
[FEAT#52]: PICK 메시지 구현

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum NotificationType {
 
     APPOINTMENT_PROPOSAL("약속 제시 알림", "'%s'님이 새로운 약속을 제시하였습니다."),
+    APPOINTMENT_CANCEL("약속 취소 알림", "'%s'님이 약속을 취소하였습니다."),
     APPOINTMENT_REMINDER("약속 리마인더 알림", "'%s' PICK 날짜가 다가오고 있습니다! 잊지 말고 준비해주세요."),
     APPOINTMENT_CONFIRMATION("약속 확정 알림", "요청하신 '%s' PICK이 확정되었습니다."),
     CHAT_MESSAGE("새로운 메시지", "'%s'님이 새로운 메시지를 보냈습니다.");

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -120,7 +120,7 @@ public class AppointmentService
 
         /// 제품 소유자에게 약속 제시 알림
 
-        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_PROPOSAL, appointment.getId().toString(), item.getOwner().getNickname());
+        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_PROPOSAL, appointment.getId().toString(), requester.getNickname());
         fcmService.sendNotification(item.getOwner().getFcmToken(), notificationReq);
 
         /// PICK 메시지 전송

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -353,6 +353,29 @@ public class AppointmentService
         // 약속 데이터 변경
         appointment.update(user, dto, appointment.getType() == AppointmentType.RENTAL);
 
+        /// 채팅방 조회 (존재하지 않으면 생성)
+
+        ChatRoom chatRoom = chatService.createChatRoom(item, user);
+
+        /// PICK 메시지 전송
+
+        // 채팅 저장
+        Chat chat = Chat.builder()
+                .chatRoomId(chatRoom.getId())
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .content(user.getNickname() + " 님께서 설정하신 " + (appointment.getType() == AppointmentType.RENTAL ? "대여" : "구매") + " 정보가 도착했어요.")
+                .isPick(true)
+                .pickInfo(Chat.PickInfo.from(appointment))
+                .build();
+
+        chatRepository.save(chat);
+
+        // 채팅 전송
+        chatWebSocketService.sendChatMessage(user, chatRoom, chat);
+
+        /// 데이터 반환
+
         // 약속 데이터 반환
         return AppointmentRes.from(appointment);
     }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -268,6 +268,15 @@ public class AppointmentService
         // 채팅 전송
         chatWebSocketService.sendChatMessage(user, chatRoom, cancelChat);
 
+        /// 채팅 상대방에게 약속 취소 알림 전송
+
+        // 채팅 상대방 조회
+        User opponent = Objects.equals(chatRoom.getRequester().getId(), user.getId()) ? chatRoom.getOwner() : chatRoom.getRequester();
+
+        // 푸시 알림 전송
+        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_PROPOSAL, appointment.getId().toString(), user.getNickname());
+        fcmService.sendNotification(opponent.getFcmToken(), notificationReq);
+
         // TODO: 사용자 피드백 요청
 
         // 약속 데이터 반환

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -274,7 +274,7 @@ public class AppointmentService
         User opponent = Objects.equals(chatRoom.getRequester().getId(), user.getId()) ? chatRoom.getOwner() : chatRoom.getRequester();
 
         // 푸시 알림 전송
-        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_PROPOSAL, appointment.getId().toString(), user.getNickname());
+        FCMNotificationReq notificationReq = FCMNotificationReq.of(NotificationType.APPOINTMENT_CANCEL, appointment.getId().toString(), user.getNickname());
         fcmService.sendNotification(opponent.getFcmToken(), notificationReq);
 
         // TODO: 사용자 피드백 요청

--- a/src/main/java/com/airfryer/repicka/domain/chat/dto/ChatPageDto.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/dto/ChatPageDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Builder
 public class ChatPageDto
 {
-    private List<ChatContent> messages;  // 채팅 리스트
+    private List<ChatContent> messages;     // 채팅 리스트
     private String cursorId;                // 채팅: 커서 ID
     private Boolean hasNext;                // 채팅: 다음 페이지가 존재하는가?
 

--- a/src/main/java/com/airfryer/repicka/domain/chat/dto/message/sub/content/ChatContent.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/dto/message/sub/content/ChatContent.java
@@ -11,11 +11,12 @@ import java.util.Date;
 @SuperBuilder
 public class ChatContent extends SubMessageContent
 {
-    private String chatId;      // 채팅 ID
-    private Long userId;        // 사용자 ID
-    private String content;     // 내용
-    private Boolean isPick;     // PICK 여부
-    private Date createdAt;     // 채팅 생성 날짜
+    private String chatId;              // 채팅 ID
+    private Long userId;                // 사용자 ID
+    private String content;             // 내용
+    private Boolean isPick;             // PICK 여부
+    private Chat.PickInfo pickInfo;     // PICK 정보
+    private Date createdAt;             // 채팅 생성 날짜
 
     public static ChatContent from(Chat chat)
     {
@@ -24,6 +25,7 @@ public class ChatContent extends SubMessageContent
                 .userId(chat.getUserId())
                 .content(chat.getContent())
                 .isPick(chat.getIsPick())
+                .pickInfo(chat.getPickInfo())
                 .createdAt(chat.getId().getDate())
                 .build();
     }

--- a/src/main/java/com/airfryer/repicka/domain/chat/entity/Chat.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/entity/Chat.java
@@ -1,5 +1,6 @@
 package com.airfryer.repicka.domain.chat.entity;
 
+import com.airfryer.repicka.domain.appointment.entity.Appointment;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -7,10 +8,12 @@ import lombok.*;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDateTime;
+
 @Document(collection = "chat")
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Builder
 public class Chat
 {
@@ -36,4 +39,65 @@ public class Chat
     // PICK 여부
     @NotNull
     private Boolean isPick;
+
+    private PickInfo pickInfo;
+
+    @Getter
+    @Builder(access = AccessLevel.PRIVATE)
+    public static class PickInfo
+    {
+        // 약속 ID
+        private Long appointmentId;
+
+        // 요청자 ID
+        private Long requesterId;
+
+        // 제품 소유자 ID
+        private Long ownerId;
+
+        // PICK 생성자 ID
+        private Long creatorId;
+
+        // 약속 종류
+        private String type;
+
+        // 약속 상태
+        private String state;
+
+        // 대여(구매) 일시
+        private LocalDateTime rentalDate;
+
+        // 반납 일시
+        private LocalDateTime returnDate;
+
+        // 대여(구매) 장소
+        private String rentalLocation;
+
+        // 반납 장소
+        private String returnLocation;
+
+        // 대여료(판매값)
+        private int price;
+
+        // 보증금
+        private int deposit;
+
+        public static PickInfo from(Appointment appointment)
+        {
+            return PickInfo.builder()
+                    .appointmentId(appointment.getId())
+                    .requesterId(appointment.getRequester().getId())
+                    .ownerId(appointment.getRequester().getId())
+                    .creatorId(appointment.getRequester().getId())
+                    .type(appointment.getType().name())
+                    .state(appointment.getState().name())
+                    .rentalDate(appointment.getRentalDate())
+                    .returnDate(appointment.getReturnDate())
+                    .rentalLocation(appointment.getRentalLocation())
+                    .returnLocation(appointment.getReturnLocation())
+                    .price(appointment.getPrice())
+                    .deposit(appointment.getDeposit())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/entity/Chat.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/entity/Chat.java
@@ -40,6 +40,7 @@ public class Chat
     @NotNull
     private Boolean isPick;
 
+    // PICK 정보
     private PickInfo pickInfo;
 
     @Getter

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatWebSocketService.java
@@ -73,10 +73,18 @@ public class ChatWebSocketService
                 .nickname(user.getNickname())
                 .content(dto.getContent())
                 .isPick(false)
+                .pickInfo(null)
                 .build();
 
         chatRepository.save(chat);
 
+        sendChatMessage(user, chatRoom, chat);
+    }
+
+    // 채팅 전송
+    @Transactional
+    public void sendChatMessage(User user, ChatRoom chatRoom, Chat chat)
+    {
         /// 채팅방 마지막 채팅 시점 갱신
 
         chatRoom.renewLastChatAt();
@@ -96,7 +104,7 @@ public class ChatWebSocketService
 
             applicationEventPublisher.publishEvent(SubMessageEvent.builder()
                     .userId(null)
-                    .destination("/sub/chatroom/" + dto.getChatRoomId())
+                    .destination("/sub/chatroom/" + chatRoom.getId())
                     .message(message)
                     .build());
 


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#52 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->

### 1. PICK 메시지 구현

<br/>

`Chat` 클래스 내에 `PickInfo` 서브 클래스를 생성함으로써 `Chat`이 PICK 정보를 가질 수 있게 하였습니다.
채팅이 PICK 메시지인 경우 `pickInfo` 변수는 해당 약속에 대한 데이터를 가지고 있으며, PICK 메시지가 아니라면 `null` 값을 가집니다.

<br/>

이제, 다음 API들이 성공적으로 호출되면 PICK 메시지(WebSocket 구독 메시지)가 전송됩니다.
- **대여 약속 제시 API**
- **구매 약속 제시 API**
- **협의 중인 약속 수정 API**
- **확정된 약속 수정 API**

<br/>

이제, 다음 API들의 채팅 정보에도 `pickInfo`가 추가됩니다.
- **대여 약속 제시 API**
- **구매 약속 제시 API**
- **채팅 불러오기 API**
- **채팅방 ID로 채팅방에 입장할 때 필요한 데이터를 조회 API**

<br/>

### 2. 약속 취소 및 확정된 약속 수정 시, 채팅 및 푸시 알림 전송

<br/>

다음 API들이 성공적으로 호출되면 자동으로 약속 취소 채팅과 푸시 알림이 전송됩니다.
- **약속 취소 API**
-  **확정된 약속 수정 API**

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
-

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>