### PR TITLE
[FEAT#52]: 채팅방 나가기 구현 

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/configuration/websocket/WebSocketAccessInterceptor.java
+++ b/src/main/java/com/airfryer/repicka/common/configuration/websocket/WebSocketAccessInterceptor.java
@@ -66,6 +66,11 @@ public class WebSocketAccessInterceptor implements ChannelInterceptor
                 ParticipateChatRoom participateChatRoom = participateChatRoomRepository.findByChatRoomIdAndParticipantId(chatRoom.getId(), userId)
                         .orElseThrow(() -> new CustomException(CustomExceptionCode.PARTICIPATE_CHATROOM_NOT_FOUND, null));
 
+                // 이미 채팅방을 나갔는지 확인
+                if(participateChatRoom.getHasLeftRoom()) {
+                    throw new CustomException(CustomExceptionCode.ALREADY_LEFT_CHATROOM, null);
+                }
+
                 // (세션 ID + 구독 ID, 채팅방 ID) 매핑 정보 저장
                 mappingSubWithRoomManager.set(accessor.getSessionId(), accessor.getSubscriptionId(), chatRoomId);
 

--- a/src/main/java/com/airfryer/repicka/common/configuration/websocket/WebSocketAccessInterceptor.java
+++ b/src/main/java/com/airfryer/repicka/common/configuration/websocket/WebSocketAccessInterceptor.java
@@ -42,8 +42,8 @@ public class WebSocketAccessInterceptor implements ChannelInterceptor
     private final ChatRepository chatRepository;
     private final ParticipateChatRoomRepository participateChatRoomRepository;
 
-    ChatWebSocketService chatWebSocketService;
-    FCMService fcmService;
+    private final ChatWebSocketService chatWebSocketService;
+    private final FCMService fcmService;
 
     private final OnlineStatusManager onlineStatusManager;
     private final MappingSubWithRoomManager mappingSubWithRoomManager;

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -65,6 +65,7 @@ public enum CustomExceptionCode
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 데이터를 찾을 수 없습니다."),
     PARTICIPATE_CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 참여 정보 데이터를 찾을 수 없습니다."),
     INVALID_CHAT_MESSAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 채팅 메시지 형식입니다."),
+    ALREADY_LEFT_CHATROOM(HttpStatus.CONFLICT, "이미 나간 채팅방입니다."),
     ALREADY_FINISHED_CHATROOM(HttpStatus.CONFLICT, "이미 종료된 채팅방입니다."),
     INTERNAL_CHAT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 오류로 인해 채팅이 정상적으로 전송되지 않았습니다."),
 

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -47,6 +47,7 @@ public enum CustomExceptionCode
     CANNOT_RESPONSE_UPDATE_IN_PROGRESS_APPOINTMENT_MYSELF(HttpStatus.FORBIDDEN, "본인이 제시한 대여중 약속 변경 제시를 본인이 수락 또는 거절할 수는 없습니다."),
     CANNOT_DELETE_OTHERS_UPDATE_IN_PROGRESS_APPOINTMENT_MYSELF(HttpStatus.FORBIDDEN, "타인이 제시한 대여중 약속 변경 제시를 본인이 취소할 수는 없습니다."),
     CURRENT_APPOINTMENT_EXIST(HttpStatus.CONFLICT, "완료되지 않은 약속이 존재합니다."),
+    IN_PROGRESS_APPOINTMENT_EXIST(HttpStatus.CONFLICT, "완료되지 않은 대여 중인 약속이 존재합니다."),
     ALREADY_RENTAL_RESERVED_PERIOD(HttpStatus.CONFLICT, "해당 구간 동안 이미 대여 약속이 예정되어 있습니다."),
     ALREADY_SALE_RESERVED_PERIOD(HttpStatus.CONFLICT, "해당 구간 동안 이미 판매 약속이 예정되어 있습니다."),
     CONFLICT_APPOINTMENT_STATE(HttpStatus.CONFLICT, "현재 약속 상태는 해당 요청을 처리할 수 없습니다."),

--- a/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
@@ -12,6 +12,7 @@ public enum NotificationType {
     APPOINTMENT_REMINDER("약속 리마인더 알림", "'%s' PICK 날짜가 다가오고 있습니다! 잊지 말고 준비해주세요."),
     APPOINTMENT_CONFIRMATION("약속 확정 알림", "요청하신 '%s' PICK이 확정되었습니다."),
     LEAVE_CHATROOM("채팅방 나가기 알림", "'%s'님이 채팅방을 나갔습니다."),
+    RE_ENTER_CHATROOM("채팅방 재입장 알림", "'%s'님이 채팅방에 재입장 하였습니다."),
     CHAT_MESSAGE("새로운 메시지", "'%s'님이 새로운 메시지를 보냈습니다.");
     
     private final String title;

--- a/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
+++ b/src/main/java/com/airfryer/repicka/common/firebase/type/NotificationType.java
@@ -10,6 +10,7 @@ public enum NotificationType {
     APPOINTMENT_PROPOSAL("약속 제시 알림", "'%s'님이 새로운 약속을 제시하였습니다."),
     APPOINTMENT_REMINDER("약속 리마인더 알림", "'%s' PICK 날짜가 다가오고 있습니다! 잊지 말고 준비해주세요."),
     APPOINTMENT_CONFIRMATION("약속 확정 알림", "요청하신 '%s' PICK이 확정되었습니다."),
+    LEAVE_CHATROOM("채팅방 나가기 알림", "'%s'님이 채팅방을 나갔습니다."),
     CHAT_MESSAGE("새로운 메시지", "'%s'님이 새로운 메시지를 보냈습니다.");
     
     private final String title;

--- a/src/main/java/com/airfryer/repicka/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/controller/ChatController.java
@@ -88,4 +88,19 @@ public class ChatController
                         .data(data)
                         .build());
     }
+
+    // 채팅방 나가기
+    @PatchMapping("/chatroom/{chatRoomId}/leave")
+    public ResponseEntity<SuccessResponseDto> leaveChatRoom(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+                                                            @PathVariable Long chatRoomId)
+    {
+        User user = oAuth2User.getUser();
+        chatService.leaveChatRoom(user, chatRoomId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("채팅방을 성공적으로 나갔습습니다.")
+                        .data(null)
+                        .build());
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/entity/ChatRoom.java
@@ -62,4 +62,12 @@ public class ChatRoom extends BaseEntity
         this.lastChatAt = LocalDateTime.now();
         this.isFinished = true;
     }
+
+    /// 채팅방 재시작
+
+    public void restart()
+    {
+        this.lastChatAt = LocalDateTime.now();
+        this.isFinished = false;
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/entity/ChatRoom.java
@@ -54,4 +54,12 @@ public class ChatRoom extends BaseEntity
     public void renewLastChatAt() {
         this.lastChatAt = LocalDateTime.now();
     }
+
+    /// 채팅방 종료
+
+    public void finish()
+    {
+        this.lastChatAt = LocalDateTime.now();
+        this.isFinished = true;
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/entity/ParticipateChatRoom.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/entity/ParticipateChatRoom.java
@@ -42,6 +42,11 @@ public class ParticipateChatRoom extends BaseEntity
     @Builder.Default
     private int unreadChatCount = 0;
 
+    // 채팅방 나감 여부
+    @NotNull
+    @Builder.Default
+    private Boolean hasLeftRoom = false;
+
     /// 채팅방 참여 정보 갱신
 
     public void renew()
@@ -51,7 +56,16 @@ public class ParticipateChatRoom extends BaseEntity
     }
 
     /// 읽지 않은 채팅 개수 증가
+
     public void increaseUnreadChatCount() {
         this.unreadChatCount++;
+    }
+
+    /// 채팅방 나가기
+
+    public void leave()
+    {
+        this.lastEnterAt = LocalDateTime.now();
+        this.hasLeftRoom = true;
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/entity/ParticipateChatRoom.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/entity/ParticipateChatRoom.java
@@ -68,4 +68,12 @@ public class ParticipateChatRoom extends BaseEntity
         this.lastEnterAt = LocalDateTime.now();
         this.hasLeftRoom = true;
     }
+
+    /// 채팅방 재입장
+
+    public void reEnter()
+    {
+        this.lastEnterAt = LocalDateTime.now();
+        this.hasLeftRoom = false;
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/entity/ParticipateChatRoom.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/entity/ParticipateChatRoom.java
@@ -22,7 +22,7 @@ public class ParticipateChatRoom extends BaseEntity
 
     // 채팅방
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "chat_room")
     private ChatRoom chatRoom;
 

--- a/src/main/java/com/airfryer/repicka/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/repository/ChatRoomRepository.java
@@ -1,79 +1,14 @@
 package com.airfryer.repicka.domain.chat.repository;
 
 import com.airfryer.repicka.domain.chat.entity.ChatRoom;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>
 {
-    /// 사용자 ID로 채팅방 페이지 조회
-
-    // 첫 페이지 조회
-    @Query("""
-        SELECT cr FROM ChatRoom cr
-        WHERE cr.requester.id = :userId OR cr.owner.id = :userId
-        ORDER BY cr.lastChatAt DESC, cr.id DESC
-    """)
-    List<ChatRoom> findFirstPageByUserId(
-            @Param("userId") Long userId,
-            Pageable pageable
-    );
-
-    // 처음 이후 페이지 조회
-    @Query("""
-        SELECT cr FROM ChatRoom cr
-        WHERE (cr.requester.id = :userId OR cr.owner.id = :userId)
-          AND (
-            cr.lastChatAt < :cursorLastChatAt
-            OR (cr.lastChatAt = :cursorLastChatAt AND cr.id <= :cursorId)
-          )
-        ORDER BY cr.lastChatAt DESC, cr.id DESC
-    """)
-    List<ChatRoom> findPageByUserId(
-            @Param("userId") Long userId,
-            @Param("cursorLastChatAt") LocalDateTime cursorLastChatAt,
-            @Param("cursorId") Long cursorId,
-            Pageable pageable
-    );
-
-    /// 제품 ID로 채팅방 페이지 조회
-
-    // 첫 페이지 조회
-    @Query("""
-        SELECT cr FROM ChatRoom cr
-        WHERE cr.item.id = :itemId
-        ORDER BY cr.lastChatAt DESC, cr.id DESC
-    """)
-    List<ChatRoom> findFirstPageByItemId(
-            @Param("itemId") Long itemId,
-            Pageable pageable
-    );
-
-    // 처음 이후 페이지 조회
-    @Query("""
-        SELECT cr FROM ChatRoom cr
-        WHERE (cr.item.id = :itemId)
-          AND (
-            cr.lastChatAt < :cursorLastChatAt
-            OR (cr.lastChatAt = :cursorLastChatAt AND cr.id <= :cursorId)
-          )
-        ORDER BY cr.lastChatAt DESC, cr.id DESC
-    """)
-    List<ChatRoom> findPageByItemId(
-            @Param("itemId") Long itemId,
-            @Param("cursorLastChatAt") LocalDateTime cursorLastChatAt,
-            @Param("cursorId") Long cursorId,
-            Pageable pageable
-    );
-
     /// 제품 ID, 소유자 ID, 요청자 ID로 채팅방 조회
 
     Optional<ChatRoom> findByItemIdAndOwnerIdAndRequesterId(Long itemId, Long userId, Long requesterId);

--- a/src/main/java/com/airfryer/repicka/domain/chat/repository/ParticipateChatRoomRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/repository/ParticipateChatRoomRepository.java
@@ -1,14 +1,80 @@
 package com.airfryer.repicka.domain.chat.repository;
 
 import com.airfryer.repicka.domain.chat.entity.ParticipateChatRoom;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ParticipateChatRoomRepository extends JpaRepository<ParticipateChatRoom, Long>
 {
     /// 채팅방 ID, 사용자 ID로 채팅방 참여 정보 조회
+
     Optional<ParticipateChatRoom> findByChatRoomIdAndParticipantId(Long chatRoomId, Long participantId);
+
+    /// 사용자 ID로 나가지 않은 채팅방 참여 정보 페이지 조회
+
+    // 첫 페이지 조회
+    @Query("""
+        SELECT pc FROM ParticipateChatRoom pc
+        WHERE pc.participant.id = :userId AND pc.hasLeftRoom = false
+        ORDER BY pc.chatRoom.lastChatAt DESC, pc.chatRoom.id DESC
+    """)
+    List<ParticipateChatRoom> findFirstPageByUserId(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+
+    // 처음 이후 페이지 조회
+    @Query("""
+        SELECT pc FROM ParticipateChatRoom pc
+        WHERE pc.participant.id = :userId AND pc.hasLeftRoom = false
+          AND (
+            pc.chatRoom.lastChatAt < :cursorLastChatAt
+            OR (pc.chatRoom.lastChatAt = :cursorLastChatAt AND pc.chatRoom.id <= :cursorId)
+          )
+        ORDER BY pc.chatRoom.lastChatAt DESC, pc.chatRoom.id DESC
+    """)
+    List<ParticipateChatRoom> findPageByUserId(
+            @Param("userId") Long userId,
+            @Param("cursorLastChatAt") LocalDateTime cursorLastChatAt,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
+
+    /// 제품 ID로 나가지 않은 채팅방 참여 정보 페이지 조회
+
+    // 첫 페이지 조회
+    @Query("""
+        SELECT pc FROM ParticipateChatRoom pc
+        WHERE pc.chatRoom.item.id = :itemId AND pc.hasLeftRoom = false
+        ORDER BY pc.chatRoom.lastChatAt DESC, pc.chatRoom.id DESC
+    """)
+    List<ParticipateChatRoom> findFirstPageByItemId(
+            @Param("itemId") Long itemId,
+            Pageable pageable
+    );
+
+    // 처음 이후 페이지 조회
+    @Query("""
+        SELECT pc FROM ParticipateChatRoom pc
+        WHERE pc.chatRoom.item.id = :itemId AND pc.hasLeftRoom = false
+          AND (
+            pc.chatRoom.lastChatAt < :cursorLastChatAt
+            OR (pc.chatRoom.lastChatAt = :cursorLastChatAt AND pc.chatRoom.id <= :cursorId)
+          )
+        ORDER BY pc.chatRoom.lastChatAt DESC, pc.chatRoom.id DESC
+    """)
+    List<ParticipateChatRoom> findPageByItemId(
+            @Param("itemId") Long itemId,
+            @Param("cursorLastChatAt") LocalDateTime cursorLastChatAt,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -316,7 +316,7 @@ public class ChatService
 
             /// 약속 취소 처리
 
-            // 제품의 판매 예정 날짜 변경
+            // 제품의 판매 예정 날짜 초기화
             currentAppointment.getItem().cancelSale();
 
             // 약속 취소

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -185,19 +185,23 @@ public class ChatService
         // Pageable 객체 생성
         Pageable pageable = PageRequest.of(0, dto.getPageSize() + 1);
 
-        // 채팅방 페이지
-        List<ChatRoom> chatRoomList;
+        // 채팅방 참여 정보 페이지
+        List<ParticipateChatRoom> participateChatRoomList;
 
         // 채팅방 페이지 조회
         if(dto.getCursorLastChatAt() == null || dto.getCursorId() == null) {
-            chatRoomList = chatRoomRepository.findFirstPageByUserId(user.getId(), pageable);
+            participateChatRoomList = participateChatRoomRepository.findFirstPageByUserId(user.getId(), pageable);
         } else {
-            chatRoomList = chatRoomRepository.findPageByUserId(user.getId(), dto.getCursorLastChatAt(), dto.getCursorId(), pageable);
+            participateChatRoomList = participateChatRoomRepository.findPageByUserId(user.getId(), dto.getCursorLastChatAt(), dto.getCursorId(), pageable);
         }
 
         /// 데이터 반환
 
-        return createChatRoomListDto(user, chatRoomList, dto.getPageSize());
+        return createChatRoomListDto(
+                user,
+                participateChatRoomList.stream().map(ParticipateChatRoom::getChatRoom).toList(),
+                dto.getPageSize()
+        );
     }
 
     // 내 제품의 채팅방 페이지 조회
@@ -220,19 +224,23 @@ public class ChatService
         // Pageable 객체 생성
         Pageable pageable = PageRequest.of(0, dto.getPageSize() + 1);
 
-        // 채팅방 페이지
-        List<ChatRoom> chatRoomList;
+        // 채팅방 참여 정보 페이지
+        List<ParticipateChatRoom> participateChatRoomList;
 
         // 채팅방 페이지 조회
         if(dto.getCursorLastChatAt() == null || dto.getCursorId() == null) {
-            chatRoomList = chatRoomRepository.findFirstPageByItemId(itemId, pageable);
+            participateChatRoomList = participateChatRoomRepository.findFirstPageByItemId(itemId, pageable);
         } else {
-            chatRoomList = chatRoomRepository.findPageByItemId(itemId, dto.getCursorLastChatAt(), dto.getCursorId(), pageable);
+            participateChatRoomList = participateChatRoomRepository.findPageByItemId(itemId, dto.getCursorLastChatAt(), dto.getCursorId(), pageable);
         }
 
         /// 데이터 반환
 
-        return createChatRoomListDto(user, chatRoomList, dto.getPageSize());
+        return createChatRoomListDto(
+                user,
+                participateChatRoomList.stream().map(ParticipateChatRoom::getChatRoom).toList(),
+                dto.getPageSize()
+        );
     }
 
     // 채팅 불러오기

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -74,8 +74,6 @@ public class ChatService
 
         ChatRoom chatRoom = createChatRoom(item, requester);
 
-        // TODO: PICK 메시지 전송
-
         /// 채팅방 입장 데이터 반환
 
         return enterChatRoom(requester, chatRoom, 1);
@@ -247,7 +245,17 @@ public class ChatService
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new CustomException(CustomExceptionCode.CHATROOM_NOT_FOUND, chatRoomId));
 
+        /// 채팅방 참여 데이터 조회
+
+        ParticipateChatRoom participateChatRoom = participateChatRoomRepository.findByChatRoomIdAndParticipantId(chatRoom.getId(), user.getId())
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.PARTICIPATE_CHATROOM_NOT_FOUND, null));
+
         /// 예외 처리
+
+        // 이미 채팅방을 나갔는지 확인
+        if(participateChatRoom.getHasLeftRoom()) {
+            throw new CustomException(CustomExceptionCode.ALREADY_LEFT_CHATROOM, null);
+        }
 
         // 채팅방 관계자인지 확인
         if(!Objects.equals(user.getId(), chatRoom.getRequester().getId()) && !Objects.equals(user.getId(), chatRoom.getOwner().getId())) {

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -468,6 +468,34 @@ public class ChatService
         // 채팅방이 존재하지 않는다면 새로 생성하여 반환
         if(chatRoomOptional.isPresent())
         {
+            // 기존 채팅방
+            ChatRoom chatRoom = chatRoomOptional.get();
+
+            /// 채팅방 재입장
+
+            // 채팅방 참여 정보 조회
+            ParticipateChatRoom participateChatRoom = participateChatRoomRepository.findByChatRoomIdAndParticipantId(chatRoom.getId(), requester.getId())
+                    .orElseThrow(() -> new CustomException(CustomExceptionCode.PARTICIPATE_CHATROOM_NOT_FOUND, null));
+
+            // 요청자가 이미 채팅방을 나간 경우, 채팅방 재입장
+            if(participateChatRoom.getHasLeftRoom()) {
+                participateChatRoom.reEnter();
+            }
+
+            /// 채팅방 재시작
+
+            // 채팅 상대방 조회
+            User opponent = Objects.equals(chatRoom.getRequester().getId(), requester.getId()) ? chatRoom.getOwner() : chatRoom.getRequester();
+
+            // 채팅방 상대방 참여 정보 조회
+            ParticipateChatRoom opponentParticipateChatRoom = participateChatRoomRepository.findByChatRoomIdAndParticipantId(chatRoom.getId(), opponent.getId())
+                    .orElseThrow(() -> new CustomException(CustomExceptionCode.PARTICIPATE_CHATROOM_NOT_FOUND, null));
+
+            // 상대방이 채팅방을 나가지 않은 경우, 채팅방 재시작
+            if(!opponentParticipateChatRoom.getHasLeftRoom()) {
+                chatRoom.restart();
+            }
+
             return chatRoomOptional.get();
         }
         else

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -397,8 +397,8 @@ public class ChatService
         chatWebSocketService.sendChatMessage(user, chatRoom, leaveChat);
 
         // 푸시 알림 전송
-        FCMNotificationReq LeaveNotificationReq = FCMNotificationReq.of(NotificationType.LEAVE_CHATROOM, chatRoom.getId().toString(), user.getNickname());
-        fcmService.sendNotification(opponent.getFcmToken(), LeaveNotificationReq);
+        FCMNotificationReq leaveNotificationReq = FCMNotificationReq.of(NotificationType.LEAVE_CHATROOM, chatRoom.getId().toString(), user.getNickname());
+        fcmService.sendNotification(opponent.getFcmToken(), leaveNotificationReq);
     }
 
     /// 공통 로직

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -97,7 +97,17 @@ public class ChatService
     @Transactional
     public EnterChatRoomRes enterChatRoom(User user, ChatRoom chatRoom, int pageSize)
     {
+        /// 채팅방 참여 데이터 조회
+
+        ParticipateChatRoom participateChatRoom = participateChatRoomRepository.findByChatRoomIdAndParticipantId(chatRoom.getId(), user.getId())
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.PARTICIPATE_CHATROOM_NOT_FOUND, null));
+
         /// 예외 처리
+
+        // 이미 채팅방을 나갔는지 확인
+        if(participateChatRoom.getHasLeftRoom()) {
+            throw new CustomException(CustomExceptionCode.ALREADY_LEFT_CHATROOM, null);
+        }
 
         // 채팅방 관계자인지 확인
         if(!Objects.equals(user.getId(), chatRoom.getRequester().getId()) && !Objects.equals(user.getId(), chatRoom.getOwner().getId())) {

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -282,8 +282,14 @@ public class ChatService
     {
         /// 채팅방 참여 데이터 조회
 
+        // 채팅방 참여 데이터 조회
         ParticipateChatRoom participateChatRoom = participateChatRoomRepository.findByChatRoomIdAndParticipantId(chatRoomId, user.getId())
                 .orElseThrow(() -> new CustomException(CustomExceptionCode.PARTICIPATE_CHATROOM_NOT_FOUND, null));
+
+        // 이미 채팅방을 나갔는지 확인
+        if(participateChatRoom.getHasLeftRoom()) {
+            throw new CustomException(CustomExceptionCode.ALREADY_LEFT_CHATROOM, null);
+        }
 
         /// 채팅방 조회
 

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatWebSocketService.java
@@ -12,7 +12,6 @@ import com.airfryer.repicka.domain.chat.entity.Chat;
 import com.airfryer.repicka.domain.chat.entity.ChatRoom;
 import com.airfryer.repicka.domain.chat.entity.ParticipateChatRoom;
 import com.airfryer.repicka.domain.chat.repository.ChatRepository;
-import com.airfryer.repicka.domain.chat.repository.ChatRoomRepository;
 import com.airfryer.repicka.domain.chat.repository.ParticipateChatRoomRepository;
 import com.airfryer.repicka.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +27,6 @@ import java.util.Objects;
 @Slf4j
 public class ChatWebSocketService
 {
-    private final ChatRoomRepository chatRoomRepository;
     private final ChatRepository chatRepository;
     private final ParticipateChatRoomRepository participateChatRoomRepository;
 

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatWebSocketService.java
@@ -41,13 +41,22 @@ public class ChatWebSocketService
     @Transactional
     public void sendChatMessage(User user, SendChatMessage dto)
     {
+        /// 채팅 상대방의 읽지 않은 채팅 개수 증가
+
+        // 채팅방 참여 정보 조회
+        ParticipateChatRoom participateChatRoom = participateChatRoomRepository.findByChatRoomIdAndParticipantId(dto.getChatRoomId(), user.getId())
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.PARTICIPATE_CHATROOM_NOT_FOUND, null));
+
         /// 채팅방 조회
 
-        // 채팅방 조회
-        ChatRoom chatRoom = chatRoomRepository.findById(dto.getChatRoomId())
-                .orElseThrow(() -> new CustomException(CustomExceptionCode.CHATROOM_NOT_FOUND, dto.getChatRoomId()));
+        ChatRoom chatRoom = participateChatRoom.getChatRoom();
 
         /// 예외 처리
+
+        // 이미 채팅방을 나갔는지 확인
+        if(participateChatRoom.getHasLeftRoom()) {
+            throw new CustomException(CustomExceptionCode.ALREADY_LEFT_CHATROOM, null);
+        }
 
         // 이미 종료된 채팅방인지 확인
         if(chatRoom.getIsFinished()) {


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#52 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->

> **채팅방 나가기 API
( [PATCH] /api/v1/chatroom/{채팅방 ID}/leave )**
> 

<br>

채팅방을 나간 즉시 다음과 같이 처리됩니다.

- 협의 중이거나 확정된 약속 자동 취소 (대여 중인 약속이 있다면 채팅방이 나가지지 않음)
- **약속 취소 및 채팅방 나가기 채팅/알림 전송**
- 채팅방 종료

<br>

채팅방을 나간 이후에는 다음과 같이 처리됩니다.

- 내 채팅방 또는 내 제품의 채팅방 조회시, 해당 채팅방이 검색되지 않음
- 해당 채팅방에 대해 다음 기능이 불가능
    - 채팅방에 입장할 때 필요한 데이터 조회
    - 채팅 전송
    - 채팅 불러오기
    - 채팅방 나가기

<br>

단, 다음의 경우에는 채팅방에 재입장하며, 상대방이 나가지 않았다면 채팅방이 재시작됩니다.

- 채팅방 입장(구독)
- 채팅방 생성
- 약속 제시

**→ 재입장 채팅/알림 전송**

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
-

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>