### PR TITLE
[FEAT#84]: 유저 차단 구현

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -21,6 +21,8 @@ public enum CustomExceptionCode
     // 사용자 관련 예외
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 데이터를 찾을 수 없습니다."),
     SAME_REPORTER_AND_REPORTED(HttpStatus.BAD_REQUEST, "본인이 본인을 신고할 수 없습니다."),
+    SAME_BLOCKER_AND_BLOCKED(HttpStatus.BAD_REQUEST, "본인이 본인을 차단할 수 없습니다."),
+    ALREADY_BLOCKED_USER(HttpStatus.CONFLICT, "이미 차단한 사용자입니다."),
 
     // 제품(Item) 관련 예외
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "제품 데이터를 찾을 수 없습니다."),

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -22,7 +22,6 @@ public enum CustomExceptionCode
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 데이터를 찾을 수 없습니다."),
     SAME_REPORTER_AND_REPORTED(HttpStatus.BAD_REQUEST, "본인이 본인을 신고할 수 없습니다."),
     SAME_BLOCKER_AND_BLOCKED(HttpStatus.BAD_REQUEST, "본인이 본인을 차단할 수 없습니다."),
-    ALREADY_BLOCKED_USER(HttpStatus.CONFLICT, "이미 차단한 사용자입니다."),
 
     // 제품(Item) 관련 예외
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "제품 데이터를 찾을 수 없습니다."),
@@ -41,11 +40,7 @@ public enum CustomExceptionCode
     NOT_APPOINTMENT_PARTICIPANT(HttpStatus.FORBIDDEN, "약속 관계자가 아닙니다."),
     APPOINTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "약속 데이터를 찾을 수 없습니다."),
     UPDATE_IN_PROGRESS_APPOINTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "대여 중인 약속 변경 제시 데이터를 찾을 수 없습니다."),
-    RETURN_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "대여 약속 제시에서 반납 일시는 필수적입니다."),
     RENTAL_DATE_IS_LATER_THAN_RETURN_DATE(HttpStatus.BAD_REQUEST, "대여 일시는 반납 일시보다 이전이어야 합니다."),
-    CURRENT_DATE_IS_LATER_THAN_RETURN_DATE(HttpStatus.BAD_REQUEST, "반납 일시는 현재 이후여야 합니다."),
-    INVALID_LOCATION(HttpStatus.BAD_REQUEST, "입력한 장소 형식이 올바르지 않습니다."),
-    PRICE_IS_NEGATIVE(HttpStatus.BAD_REQUEST, "가격은 0 또는 양수여야 합니다."),
     UNRELATED_ITEM(HttpStatus.BAD_REQUEST, "연관 없는 제품입니다."),
     CANNOT_CONFIRM_APPOINTMENT_MYSELF(HttpStatus.FORBIDDEN, "본인이 제시한 약속을 본인이 확정할 수는 없습니다."),
     CANNOT_RESPONSE_UPDATE_IN_PROGRESS_APPOINTMENT_MYSELF(HttpStatus.FORBIDDEN, "본인이 제시한 대여중 약속 변경 제시를 본인이 수락 또는 거절할 수는 없습니다."),

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -20,6 +20,7 @@ public enum CustomExceptionCode
 
     // 사용자 관련 예외
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 데이터를 찾을 수 없습니다."),
+    USER_BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 차단 데이터를 찾을 수 없습니다."),
     SAME_REPORTER_AND_REPORTED(HttpStatus.BAD_REQUEST, "본인이 본인을 신고할 수 없습니다."),
     SAME_BLOCKER_AND_BLOCKED(HttpStatus.BAD_REQUEST, "본인이 본인을 차단할 수 없습니다."),
     USER_BLOCK_EXIST(HttpStatus.CONFLICT, "유저 차단 데이터가 존재합니다."),

--- a/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
+++ b/src/main/java/com/airfryer/repicka/common/exception/CustomExceptionCode.java
@@ -22,6 +22,7 @@ public enum CustomExceptionCode
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 데이터를 찾을 수 없습니다."),
     SAME_REPORTER_AND_REPORTED(HttpStatus.BAD_REQUEST, "본인이 본인을 신고할 수 없습니다."),
     SAME_BLOCKER_AND_BLOCKED(HttpStatus.BAD_REQUEST, "본인이 본인을 차단할 수 없습니다."),
+    USER_BLOCK_EXIST(HttpStatus.CONFLICT, "유저 차단 데이터가 존재합니다."),
 
     // 제품(Item) 관련 예외
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "제품 데이터를 찾을 수 없습니다."),

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -89,7 +89,7 @@ public class AppointmentService
             throw new CustomException(CustomExceptionCode.SAME_OWNER_AND_REQUESTER, null);
         }
 
-        // 어떤 사용자가 다른 사용자를 차단했는지 체크
+        // 유저 차단 데이터 존재 여부 체크
         if(userBlockRepository.existsByUserIds(requester.getId(), item.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.USER_BLOCK_EXIST, null);
         }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/service/AppointmentService.java
@@ -26,6 +26,7 @@ import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import com.airfryer.repicka.domain.item_image.repository.ItemImageRepository;
 import com.airfryer.repicka.domain.item.entity.TransactionType;
 import com.airfryer.repicka.domain.user.entity.user.User;
+import com.airfryer.repicka.domain.user.repository.UserBlockRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +44,7 @@ public class AppointmentService
     private final ItemRepository itemRepository;
     private final ItemImageRepository itemImageRepository;
     private final ChatRepository chatRepository;
+    private final UserBlockRepository userBlockRepository;
 
     private final ChatService chatService;
     private final ChatWebSocketService chatWebSocketService;
@@ -85,6 +87,11 @@ public class AppointmentService
         // 요청자와 제품 소유자가 다른 사용자인지 체크
         if(Objects.equals(requester.getId(), item.getOwner().getId())) {
             throw new CustomException(CustomExceptionCode.SAME_OWNER_AND_REQUESTER, null);
+        }
+
+        // 어떤 사용자가 다른 사용자를 차단했는지 체크
+        if(userBlockRepository.existsByUserIds(requester.getId(), item.getOwner().getId())) {
+            throw new CustomException(CustomExceptionCode.USER_BLOCK_EXIST, null);
         }
 
         // 대여(구매) 날짜 가능 여부 체크

--- a/src/main/java/com/airfryer/repicka/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/repository/ChatRoomRepository.java
@@ -84,6 +84,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>
         SELECT c FROM ChatRoom c
         WHERE (c.owner.id = :user1Id AND c.requester.id = :user2Id) OR (c.owner.id = :user2Id AND c.requester.id = :user1Id)
     """)
-    List<ChatRoom> findByParticipants(@Param("user1Id") Long user1Id,
-                                      @Param("user2Id") Long user2Id);
+    List<ChatRoom> findByParticipantIds(@Param("user1Id") Long user1Id,
+                                        @Param("user2Id") Long user2Id);
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/repository/ChatRoomRepository.java
@@ -76,5 +76,14 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>
 
     /// 제품 ID, 소유자 ID, 요청자 ID로 채팅방 조회
 
-    Optional<ChatRoom> findByItemIdAndOwnerIdAndRequesterId(Long itemId, Long userId, Long requesterId);
+    Optional<ChatRoom> findByItemIdAndOwnerIdAndRequesterId(Long itemId, Long ownerId, Long requesterId);
+
+    /// 두 사용자 ID로 채팅방 조회
+
+    @Query("""
+        SELECT c FROM ChatRoom c
+        WHERE (c.owner.id = :user1Id AND c.requester.id = :user2Id) OR (c.owner.id = :user2Id AND c.requester.id = :user1Id)
+    """)
+    List<ChatRoom> findByParticipants(@Param("user1Id") Long user1Id,
+                                      @Param("user2Id") Long user2Id);
 }

--- a/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
+++ b/src/main/java/com/airfryer/repicka/domain/chat/service/ChatService.java
@@ -19,6 +19,7 @@ import com.airfryer.repicka.domain.item.repository.ItemRepository;
 import com.airfryer.repicka.domain.item_image.entity.ItemImage;
 import com.airfryer.repicka.domain.item_image.repository.ItemImageRepository;
 import com.airfryer.repicka.domain.user.entity.user.User;
+import com.airfryer.repicka.domain.user.repository.UserBlockRepository;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.PageRequest;
@@ -41,6 +42,7 @@ public class ChatService
     private final ItemRepository itemRepository;
     private final ItemImageRepository itemImageRepository;
     private final AppointmentRepository appointmentRepository;
+    private final UserBlockRepository userBlockRepository;
 
     private final OnlineStatusManager onlineStatusManager;
 
@@ -59,6 +61,11 @@ public class ChatService
         // 이미 삭제된 제품인 경우, 예외 처리
         if(item.getIsDeleted()) {
             throw new CustomException(CustomExceptionCode.ALREADY_DELETED_ITEM, null);
+        }
+
+        // 유저 차단 데이터 존재 여부 체크
+        if(userBlockRepository.existsByUserIds(requester.getId(), item.getOwner().getId())) {
+            throw new CustomException(CustomExceptionCode.USER_BLOCK_EXIST, null);
         }
 
         /// 채팅방 조회 (존재하지 않으면 생성)

--- a/src/main/java/com/airfryer/repicka/domain/user/UserController.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserController.java
@@ -1,5 +1,6 @@
 package com.airfryer.repicka.domain.user;
 
+import com.airfryer.repicka.domain.user.dto.BlockUserReq;
 import com.airfryer.repicka.domain.user.dto.ReportUserReq;
 import com.airfryer.repicka.domain.user.entity.user.User;
 import org.springframework.http.HttpStatus;
@@ -88,6 +89,21 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponseDto.builder()
                         .message("유저를 성공적으로 신고하였습니다.")
+                        .data(null)
+                        .build());
+    }
+
+    // 유저 차단
+    @PostMapping("/block")
+    public ResponseEntity<SuccessResponseDto> blockUser(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+                                                        @RequestBody @Valid BlockUserReq dto)
+    {
+        User blocker = customOAuth2User.getUser();
+        userService.blockUser(blocker, dto);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("유저를 성공적으로 차단하였습니다.")
                         .data(null)
                         .build());
     }

--- a/src/main/java/com/airfryer/repicka/domain/user/UserController.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserController.java
@@ -107,4 +107,19 @@ public class UserController {
                         .data(null)
                         .build());
     }
+
+    // 유저 차단 해제
+    @DeleteMapping("/unblock")
+    public ResponseEntity<SuccessResponseDto> unblockUser(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+                                                          @RequestBody @Valid BlockUserReq dto)
+    {
+        User blocker = customOAuth2User.getUser();
+        userService.unblockUser(blocker, dto);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("유저 차단을 성공적으로 해제하였습니다.")
+                        .data(null)
+                        .build());
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/UserService.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserService.java
@@ -192,4 +192,18 @@ public class UserService {
         });
 
     }
+
+    // 유저 차단 해제
+    @Transactional
+    public void unblockUser(User blocker, BlockUserReq dto)
+    {
+        /// 유저 차단 데이터 조회
+
+        UserBlock userBlock = userBlockRepository.findByBlockerIdAndBlockedId(blocker.getId(), dto.getBlockedUserId())
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.USER_BLOCK_NOT_FOUND, dto.getBlockedUserId()));
+
+        /// 유저 차단 데이터 삭제
+
+        userBlockRepository.delete(userBlock);
+    }
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/UserService.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserService.java
@@ -112,7 +112,7 @@ public class UserService {
             throw new CustomException(CustomExceptionCode.UNRELATED_ITEM, null);
         }
 
-        /// 유저 신고 데이터 존재 여부에 따른 분기 처리
+        /// 유저 신고 데이터 저장
 
         // 기존의 유저 신고 데이터 조회
         Optional<UserReport> userReportOptional = userReportRepository.findByReporterIdAndReportedIdAndItemId(
@@ -142,6 +142,10 @@ public class UserService {
 
             userReportRepository.save(userReport);
         }
+
+        /// 유저 차단
+
+        blockUser(reported, reported);
     }
 
     // 유저 차단

--- a/src/main/java/com/airfryer/repicka/domain/user/UserService.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserService.java
@@ -160,14 +160,14 @@ public class UserService {
     {
         /// 예외 처리
 
+        // 이미 차단한 사용자인 경우, 종료
+        if(userBlockRepository.findByBlockerIdAndBlockedId(blocker.getId(), blocked.getId()).isPresent()) {
+            return;
+        }
+
         // 본인이 본인을 차단하는 경우, 예외 처리
         if(Objects.equals(blocker.getId(), blocked.getId())) {
             throw new CustomException(CustomExceptionCode.SAME_BLOCKER_AND_BLOCKED, null);
-        }
-
-        // 이미 차단한 사용자인 경우, 예외 처리
-        if(userBlockRepository.findByBlockerIdAndBlockedId(blocker.getId(), blocked.getId()).isPresent()) {
-            throw new CustomException(CustomExceptionCode.ALREADY_BLOCKED_USER, null);
         }
 
         /// 유저 차단 데이터 저장

--- a/src/main/java/com/airfryer/repicka/domain/user/UserService.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserService.java
@@ -185,7 +185,7 @@ public class UserService {
 
         /// 차단한 사용자와의 모든 채팅방 순회
 
-        List<ChatRoom> chatRoomList = chatRoomRepository.findByParticipants(blocker.getId(), blocked.getId());
+        List<ChatRoom> chatRoomList = chatRoomRepository.findByParticipantIds(blocker.getId(), blocked.getId());
 
         chatRoomList.forEach(chatRoom -> {
             // TODO: 채팅방 나가기

--- a/src/main/java/com/airfryer/repicka/domain/user/dto/BlockUserReq.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/dto/BlockUserReq.java
@@ -1,0 +1,11 @@
+package com.airfryer.repicka.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class BlockUserReq
+{
+    @NotNull(message = "차단할 사용자 ID를 입력해주세요.")
+    private Long blockedUserId;
+}

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/user_block/UserBlock.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/user_block/UserBlock.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Entity
-@Table(name = "user-block")
+@Table(name = "user_block")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/src/main/java/com/airfryer/repicka/domain/user/entity/user_block/UserBlock.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/entity/user_block/UserBlock.java
@@ -1,0 +1,32 @@
+package com.airfryer.repicka.domain.user.entity.user_block;
+
+import com.airfryer.repicka.common.entity.BaseEntity;
+import com.airfryer.repicka.domain.user.entity.user.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(name = "user-block")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class UserBlock extends BaseEntity
+{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 차단자
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker")
+    private User blocker;
+
+    // 피차단자
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked")
+    private User blocked;
+}

--- a/src/main/java/com/airfryer/repicka/domain/user/repository/UserBlockRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/repository/UserBlockRepository.java
@@ -1,9 +1,14 @@
 package com.airfryer.repicka.domain.user.repository;
 
-import com.airfryer.repicka.domain.user.entity.user_report.UserReport;
+import com.airfryer.repicka.domain.user.entity.user_block.UserBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface UserBlockRepository extends JpaRepository<UserReport, Long> {
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long>
+{
+    // 차단자 ID, 피차단자 ID로 유저 차단 데이터 조회
+    Optional<UserBlock> findByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
 }

--- a/src/main/java/com/airfryer/repicka/domain/user/repository/UserBlockRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/repository/UserBlockRepository.java
@@ -1,0 +1,9 @@
+package com.airfryer.repicka.domain.user.repository;
+
+import com.airfryer.repicka.domain.user.entity.user_report.UserReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserBlockRepository extends JpaRepository<UserReport, Long> {
+}

--- a/src/main/java/com/airfryer/repicka/domain/user/repository/UserBlockRepository.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/repository/UserBlockRepository.java
@@ -2,6 +2,8 @@ package com.airfryer.repicka.domain.user.repository;
 
 import com.airfryer.repicka.domain.user.entity.user_block.UserBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,6 +11,18 @@ import java.util.Optional;
 @Repository
 public interface UserBlockRepository extends JpaRepository<UserBlock, Long>
 {
-    // 차단자 ID, 피차단자 ID로 유저 차단 데이터 조회
+    /// 차단자 ID, 피차단자 ID로 유저 차단 데이터 조회
+
     Optional<UserBlock> findByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    /// 두 사용자 ID로 유저 차단 데이터 존재 여부 확인
+
+    @Query("""
+        SELECT CASE WHEN COUNT(ub) > 0 THEN true ELSE false END
+        FROM UserBlock ub
+        WHERE (ub.blocker.id = :user1Id AND ub.blocked.id = :user2Id)
+           OR (ub.blocker.id = :user2Id AND ub.blocked.id = :user1Id)
+    """)
+    boolean existsByUserIds(@Param("user1Id") Long user1Id,
+                            @Param("user2Id") Long user2Id);
 }


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#84 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->

### 1. 유저 차단 엔티티 생성

<br>

유저 차단 데이터를 저장할 **user_block** 엔티티를 구현하였습니다.

<br>

### 2. 유저 차단 API 구현

<br>

> **유저 차단 API
( [POST] /api/v1/user/block )**

<br>

어떤 사용자가 다른 사용자를 차단한다면, 기존 데이터에 대해 다음과 같은 처리가 이루어집니다.

- 채팅방 나가기
    - 협의 중이거나 확정된 약속 자동 취소 (대여 중인 약속이 있다면 차단 불가능)
    - 다음 기능들이 불가능
        - 채팅방 ID로 채팅방에 입장할 때 필요한 데이터를 조회
        - 채팅방에 채팅 전송
        - 채팅방 나가기
        - 채팅 불러오기

<br>

또한, 앞으로 서로에게 다음과 같은 기능들을 수행할 수 없습니다.

- 약속 제시
- 채팅방 생성
- 기존 채팅방 입장(구독)

<br>

**[참고] 유저를 신고하면 자동으로 차단됩니다.**

<br>

### 3. 유저 차단 해제 API 구현

<br>

> **유저 차단 해제 API
( [DELETE] /api/v1/user/unblock )**

<br>

단순히, 유저 차단 데이터를 삭제합니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
- 채팅방 나가기 구현 PR 머지되면, 차단 시에 채팅방을 나가는 로직 추가

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>