### PR TITLE
[FEAT#88]: 채팅 생성 날짜 기준시 변경 및 대여중인 약속 존재 여부 확인 API 구현

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/configuration/MongodbConfig.java
+++ b/src/main/java/com/airfryer/repicka/common/configuration/MongodbConfig.java
@@ -2,14 +2,19 @@ package com.airfryer.repicka.common.configuration;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
 @Configuration
-@EnableMongoAuditing
+@EnableMongoAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 @RequiredArgsConstructor
 public class MongodbConfig implements InitializingBean
 {
@@ -18,5 +23,11 @@ public class MongodbConfig implements InitializingBean
     @Override
     public void afterPropertiesSet() {
         mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null));
+    }
+
+    // Auditing 서울 시간대 적용
+    @Bean(name = "auditingDateTimeProvider")
+    public DateTimeProvider dateTimeProvider() {
+        return () -> Optional.of(OffsetDateTime.now(ZoneId.of("Asia/Seoul")));
     }
 }

--- a/src/main/java/com/airfryer/repicka/domain/appointment/controller/AppointmentController.java
+++ b/src/main/java/com/airfryer/repicka/domain/appointment/controller/AppointmentController.java
@@ -150,4 +150,19 @@ public class AppointmentController
                         .data(data)
                         .build());
     }
+
+    // 대여중인 약속 존재 여부 확인
+    @GetMapping("/in-progress")
+    public ResponseEntity<SuccessResponseDto> isInProgressAppointmentPresent(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+                                                                             @RequestParam Long chatRoomId)
+    {
+        User user = oAuth2User.getUser();
+        boolean isPresent = appointmentService.isInProgressAppointmentPresent(user, chatRoomId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("대여중인 약속 존재 여부를 성공적으로 조회하였습니다.")
+                        .data(isPresent)
+                        .build());
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,9 @@
 spring:
 
+  ## 시간대 기준을 서울로 설정
+  jackson:
+    time-zone: Asia/Seoul
+
   ## PostgreSQL 연동
   datasource:
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#88 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->

### 1. 채팅 생성 날짜 기준시 변경

<br/>

MongoDB는 시간 관련 데이터를 무조건 UTC 기준으로 변환하여 저장합니다.
따라서, 클라이언트에게 보여줄 때는 서울 기준으로 변경하여 반환하도록 설정을 추가하였습니다.

<br/>

**🚨  한국 시간으로 변환하여 데이터를 저장하는 것이 아닌, 데이터를 꺼내서 쓸 때 한국 시간으로 변환하는 것입니다!**

<br/>

### 2. 대여중인 약속 존재 여부 확인 API 구현

<br/>

> **대여중인 약속 존재 여부 확인 API
( [GET] /api/v1/appointment/in-progress?chatRoomId={채팅방 ID} )**
>

<br/>

채팅방에서 나가기 전, 대여중인 약속이 존재하는지 확인하기 위해 사용됩니다.

<br>

## ✅ To-do
<!--
보완해야 할 사항을 적어주세요
!-->
-

<br>

## 💭 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
-

<br>