### PR TITLE
[FIX#110]: 회원 탈퇴 시, 로그아웃도 수행

### DIFF
--- a/src/main/java/com/airfryer/repicka/common/security/jwt/controller/TokenController.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/controller/TokenController.java
@@ -37,15 +37,12 @@ public class TokenController
                         .build());
     }
 
+    // 로그아웃
     @PostMapping("/logout")
     @PreAuthorize("permitAll()")
     public ResponseEntity<SuccessResponseDto> logout(HttpServletResponse response)
     {
-        ResponseCookie accessTokenCookie = tokenService.expireAccessToken();
-        ResponseCookie refreshTokenCookie = tokenService.expireRefreshToken();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        tokenService.logout(response);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponseDto.builder()

--- a/src/main/java/com/airfryer/repicka/common/security/jwt/service/TokenService.java
+++ b/src/main/java/com/airfryer/repicka/common/security/jwt/service/TokenService.java
@@ -6,7 +6,9 @@ import com.airfryer.repicka.common.security.jwt.JwtUtil;
 import com.airfryer.repicka.common.security.jwt.Token;
 import com.airfryer.repicka.domain.user.entity.user.User;
 import com.airfryer.repicka.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,8 @@ public class TokenService
 {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
+
+    /// 서비스
 
     // Access token 재발급
     @Transactional(readOnly = true)
@@ -55,6 +59,18 @@ public class TokenService
         // 토큰을 쿠키로 변환 후, 반환
         return jwtUtil.parseTokenToCookie(accessToken, Token.ACCESS_TOKEN);
     }
+
+    // 로그아웃
+    public void logout(HttpServletResponse response)
+    {
+        ResponseCookie accessTokenCookie = expireAccessToken();
+        ResponseCookie refreshTokenCookie = expireRefreshToken();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+    }
+
+    /// 공통 로직
 
     // Access token 만료
     public ResponseCookie expireAccessToken()

--- a/src/main/java/com/airfryer/repicka/domain/user/UserController.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserController.java
@@ -4,6 +4,7 @@ import com.airfryer.repicka.domain.user.dto.BlockUserReq;
 import com.airfryer.repicka.domain.item.dto.res.OwnedItemListRes;
 import com.airfryer.repicka.domain.user.dto.ReportUserReq;
 import com.airfryer.repicka.domain.user.entity.user.User;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -140,9 +141,11 @@ public class UserController {
 
     // 유저 탈퇴
     @DeleteMapping
-    public ResponseEntity<SuccessResponseDto> withdrawUser(@AuthenticationPrincipal CustomOAuth2User user)
+    public ResponseEntity<SuccessResponseDto> withdrawUser(HttpServletResponse response,
+                                                           @AuthenticationPrincipal CustomOAuth2User user)
     {
-        userService.withdrawUser(user.getUser());
+        userService.withdrawUser(user.getUser(), response);
+
         return ResponseEntity.ok(SuccessResponseDto.builder()
             .message("유저 탈퇴가 성공적으로 완료되었습니다.")
             .build());

--- a/src/main/java/com/airfryer/repicka/domain/user/UserService.java
+++ b/src/main/java/com/airfryer/repicka/domain/user/UserService.java
@@ -1,5 +1,6 @@
 package com.airfryer.repicka.domain.user;
 
+import com.airfryer.repicka.common.security.jwt.service.TokenService;
 import com.airfryer.repicka.domain.appointment.service.AppointmentUtil;
 import com.airfryer.repicka.domain.appointment.service.AppointmentService;
 import com.airfryer.repicka.domain.appointment.repository.AppointmentRepository;
@@ -17,6 +18,7 @@ import com.airfryer.repicka.domain.user.entity.user_block.UserBlock;
 import com.airfryer.repicka.domain.user.entity.user_report.UserReport;
 import com.airfryer.repicka.domain.user.repository.UserBlockRepository;
 import com.airfryer.repicka.domain.user.repository.UserReportRepository;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
@@ -46,11 +48,12 @@ public class UserService
     private final ChatRoomRepository chatRoomRepository;
     private final ItemRepository itemRepository;
     private final AppointmentRepository appointmentRepository;
-    private final AppointmentService appointmentService;
+    private final ItemImageRepository itemImageRepository;
 
     private final AppointmentUtil appointmentUtil;
 
-    private final ItemImageRepository itemImageRepository;
+    private final AppointmentService appointmentService;
+    private final TokenService tokenService;
     private final S3Service s3Service;
 
     // fcm 토큰 업데이트
@@ -246,7 +249,7 @@ public class UserService
 
     // 유저 탈퇴
     @Transactional
-    public void withdrawUser(User user)
+    public void withdrawUser(User user, HttpServletResponse response)
     {
         // 진행 중인 약속이 있는지 확인
         if(appointmentRepository.existsInProgressAppointmentByUserId(user.getId())) {
@@ -258,8 +261,12 @@ public class UserService
         for(Appointment appointment : appointmentsToCancel) {
             appointmentService.cancelAppointment(user, appointment.getId());
         }
-        
+
+        // 유저 탈퇴
         user.withdraw();
         userRepository.save(user);
+
+        // 로그아웃
+        tokenService.logout(response);
     }
 }


### PR DESCRIPTION
<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

## 📢 연관 이슈
<!-- #번호 -->
#110 

<br>

## 🦾 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
- `TokenController`의 `logout` 메서드의 비즈니스 로직을 `TokenService`로 분리해두었습니다.
- 유저 탈퇴 시, 로그아웃도 수행하도록 수정하였습니다.

<br>